### PR TITLE
fix(0.6.x): picker fixes + TOFU revive + sandbox dev workflow (0.6.0–0.6.7)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@ dist/
 *.log
 .DS_Store
 .npmrc
+
+dev-harness/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,148 @@
 
 All notable changes to **dsh-remote**.
 
+## 0.6.7 — 2026-08-20
+### 远程目录浏览崩溃修复 + TOFU 主机指纹校验复活
+- 修复「远程」目录选择器点浏览报 `The "data" argument must be of type string or
+  an instance of Buffer, TypedArray, or DataView. Received undefined`。
+- **根因**：ssh2 v1.17 的 `hostVerifier` 回调传入的是**裸 Buffer**（SSH
+  host-key 二进制块，SSH wire 格式），而 v0.6.1 的 TOFU 实现按旧版
+  `{ algo, hash }` 对象写的——`keyFingerprint` 对 `key.hash`（undefined）调
+  `createHash().update()` 在**每次 SSH 连接**都抛错。ls/浏览走 SSH 连接 →
+  每次必崩（单元测试用 mock 对象掩盖了契约漂移）。
+- **修复**：`keyFingerprint` 兼容裸 Buffer（对整块 blob 做 SHA-256）与
+  `{algo,hash}` 旧形态；算法名从 blob 头部解析（`blobAlgorithm`），known_hosts
+  记录 `algo=ssh-ed25519`。
+- 沙箱实测：ls 返回 myTower 真实目录列表（HTTP 200）；known_hosts 首次正确
+  写入指纹；第二次连接指纹匹配；篡改指纹后新连接被**拒绝**（MITM 告警 +
+  `/remote-forget-key` 重信任提示）。v0.6.1 的 TOFU 主机指纹校验首次在真实
+  ssh2 下真正生效。
+
+## 0.6.6 — 2026-08-20
+### 本机目录选择器：真根因修复（DSH directoryPicker 服务实测缺失）
+- 运行时诊断（沙箱临时路由）证实：`ctx.get('directoryPicker')` 实测为 **null**，
+  `directoryPicker` 从未注册——web-app 的 `-auto` 行（`-auto` → native/browse
+  后端）在桌面启动路径里不物化成 loader 条目（`loader.store` 只有 include+hmr；
+  即便 `loader.create` 手动挂载 native 后端，服务也不出现）。之前"服务存在、
+  只是 cordis 属性访问崩"的判断是错的，那只是 `without inject` 报错造成的误导。
+- `/dsh-remote/local-pick` 改为**两级策略**：优先 `ctx.get('directoryPicker')`
+  native 后端；服务缺位/非原生/抛错时**自持兜底**——插件自带原生选择器
+  （macOS `osascript choose folder` / Linux `zenity→kdialog`，与 DSH native
+  后端同一套调用约定），120s 超时 + 取消码识别。
+- 沙箱端到端实测（真实对话框交互）：取消 → `{ok:true,cancelled:true,via:'own'}`；
+  正选 → `{ok:true,path:"/Users/…",via:'own'}`，两分支均 HTTP 200。
+- 客户端 `chooseLocal()` 无需改动（已兼容 path/cancelled/error 形状）。
+
+## 0.6.5 — 2026-08-20
+### 合并上游 0.5.8–0.5.10（客户端 UI 修复）
+- 机器下拉从原生 `<select>` 改为自绘 dropdown（`ddRef` + 点击外部关闭），
+  避免原生 select 的弹出层常驻遮挡下方按钮。
+- 路径自动补全下拉支持点击外部空白处收起（`suggestRef` + `mousedown`）。
+- 纯客户端改动：刷新页面即生效，无需重启。
+### 开发模式
+- 新增 `scripts/dev-run.sh`：**开发/沙箱模式**——在隔离的 DSH_HOME + 独立
+  profile（硬链接拷贝产品 profile，`node_modules/dsh-remote` 换成指向源码的
+  symlink）上启动桌面 harness，改源码即加载，**绝不触碰产品实例**。
+  `--stop/--status/--refresh` 子命令见脚本头部。
+- `scripts/dev-standards.md` 增加「沙箱优先」规则：日常迭代一律在沙箱验证；
+  产品 profile 里的 `dsh-remote` 声明为 `^0.5.10`，任何 npm/plugin 重装都会
+  覆盖手工部署的文件（v0.6.4 曾被重装回 0.5.10 顶掉，实证）。
+
+## 0.6.4 — 2026-08-19
+### Fixes（本机目录选择器崩溃）
+- 修复「本机」目录选择器报错 `cannot get property "directoryPicker" without
+  inject`：`/dsh-remote/local-pick` 路由取 picker 服务时用
+  `ctx.directoryPicker` 属性访问作为兜底，但 cordis 规定**属性形式必须先在
+  该插件的 `inject` 列表里声明**，未声明即抛错（与服务是否注册无关）。
+  改为只用 `ctx.get('directoryPicker')`（按名解析、不要求 inject、缺失返回
+  null）。修复后 DSH Desktop（macOS/loopback 绑定）下的**原生系统文件夹
+  选择器可正常弹出**，不再需要退而手动填路径。
+- 规范化补充：可选服务一律用 `ctx.get(name)`，禁用 `ctx.<name>` 属性形式
+  （已并入 `scripts/dev-standards.md`，为第二条 cordis 约束教训）。
+
+## 0.6.3 — 2026-08-19
+### Fixes（启动崩溃）
+- 修复 0.6.1 引入的**阻塞启动**回归：slash 命令原注册为 `remote.forget-key`，
+  但 dsh-commands 框架要求命令名匹配 `/^[a-z][a-z0-9_-]*$/u`（不允许点号）。
+  非法命令名导致**插件树加载失败、DSH Desktop 无法启动**。已改名为合法的
+  `remote-forget-key`（帮助文案同步更新）。
+### 开发流程硬化
+- 新增 `check.mjs`（部署前闸门：校验所有 `commands.register()` 名符合框架约束）
+  与 `scripts/boot-smoke.sh`（在隔离的 profile 拷贝上启动桌面 harness，证明
+  插件树能加载）。`./sync.sh` 现在**拷贝前跑静态闸门、拷贝后跑启动冒烟**，
+  阻塞启动的改动无法再被静默部署。
+- 新增 `scripts/dev-standards.md`（dsh 插件开发规范，固化本次事故教训）。
+
+## 0.6.2 — 2026-08-19
+### Fixes
+- **Remote directory picker**: structured listings now run `ls -1A -F` (classifies
+  entries from readdir `d_type`, no per-entry `stat`) instead of a
+  `for f in .[!.]* *` loop that stat'ed every entry. This fixes two real
+  failure modes when browsing remote directories:
+  - Directories with **no dotfiles** no longer fail with
+    `zsh:1: no matches found: .[!.]*` (zsh `nomatch` aborts the old glob) —
+    they now list normally.
+  - Listing a directory that contains a **stuck FUSE/network mount** (e.g. an
+    unresponsive s3fs/bucket mount) no longer hangs: the old loop's `[ -d ]`
+    stat blocked in an uninterruptible kernel D-state (immune to SIGTERM),
+    holding the SSH channel until the exec timeout. `ls -F` reads d_type
+    without stat, so a dead mount can't stall the listing.
+- Symlinked directories (`/bin@` …) remain enterable: symlink entries get one
+  bounded `[ -d ]` follow-up (only symlinks are touched, never a stuck mount);
+  if that stat is slow or fails the symlink degrades to a non-enterable file
+  instead of failing the whole browse.
+
+## 0.6.1 — 2026-08-18
+### Security: host-key verification (TOFU)
+- **New `hostKeyMode` config** (`accept-new` default · `verify` · `off`): the SSH host
+  key is verified on every connect.
+  - `accept-new` records a host's key on first connect and rejects any CHANGE
+    afterwards (mirrors ssh's `StrictHostKeyChecking accept-new`) — closes the
+    man-in-the-middle gap where ssh2 silently accepted any host key.
+  - `verify` also rejects hosts never recorded before (strict).
+  - `off` disables verification (not recommended).
+- Trusted keys are stored at `$DSH_HOME/remote-workspaces/known_hosts.json`
+  (SHA-256 base64 fingerprint per `host:port`), so they migrate with the data root.
+- `rw_info` / `/remote` report host-key state; **`/remote forget-key`** and the
+  `/dsh-remote/forget-key` endpoint drop a stale/mistrusted record so the next
+  connect re-records it.
+### Robustness
+- `/dsh-remote/ls` parses `path` via URL search params (literal `+` decodes to space).
+- POST request bodies are capped at 1 MiB.
+- `/dsh-remote/mirror` now always verifies the directory over SSH (connecting if
+  needed) instead of silently minting a mirror when disconnected.
+
+## 0.6.0 — 2026-08-18
+### Cross-platform & correctness fixes
+- **Portable remote commands** — `rw_list_dir` and `rw_read_file` no longer use the
+  GNU-only `ls --color=never` / `sed -n … --` forms, so macOS/BSD remotes work too.
+- **Timeout now kills the remote process** — a timed-out `rw_exec`/`rw_read_file` sends
+  `SIGTERM` to the remote command (then hard-closes the channel), instead of silently
+  leaving it running and holding the SSH connection.
+- **SSH connect race fixed** — `SshPool` gained a generational token; switching targets
+  or closing mid-connect can no longer let a stale handshake claim the pool and point it
+  at the old host. Dropped in-flight connects are swallowed, not unhandled rejections.
+- **Mirror collision safety** — local mirrors are named `<host>-<user>-<port>/<base>`;
+  when a different remote path already took that basename, a short path-hash suffix is
+  appended so `/a/project` and `/b/project` never share a directory. First use keeps the
+  clean basename label.
+- **Persistent workspace** — picking a workspace (tool or UI) now saves it on the machine
+  record, so it survives a restart.
+- System-prompt injection text now says `rw_*` (matching the real tool names).
+### Data location
+- Machines + mirrors now follow `$DSH_HOME` (`remote-workspaces` under the harness home);
+  pre-0.6 data under `~/.dsh/remote-workspaces` is migrated automatically on first run.
+### Sync performance
+- `rw_sync` / `rw_push` are **incremental** — files whose size+mtime match are skipped;
+  local mtime is aligned on download so repeated syncs are cheap.
+- New `maxFileBytes` cap (default 50 MiB) skips oversized files instead of yanking them
+  into the mirror.
+- Directory sweeps run with **bounded parallelism** (4-way) per level.
+### New tools
+- `rw_exec` accepts `cwd` and defaults to the current remote workspace.
+- `rw_search(pattern, path?, glob?, ignoreCase?)` — portable recursive grep.
+- `rw_download(path, localPath?)` / `rw_upload(localPath, path)` — single-file transfers.
+
 ## 0.5.7 — 2026-08-15
 - **Fix boot crash (regression in 0.5.5/0.5.6):** tool schemas again use the DSH value-schema
   DSL form — `required: true` on leaf properties (the compiler derives the `required[]` array).

--- a/README.md
+++ b/README.md
@@ -34,14 +34,21 @@ Real capture (host scrubbed to a placeholder):
 
 - **Multi-machine SSH** — save any number of hosts (`host`/`port`/`user` + **private key** or **password**). Passwords are stored locally and never shown back in the UI. Switch with one click in Settings.
 - **Two-tab workspace picker** (fills the native "Add workspace" flow):
-  - **本机 / Local** — opens the **native OS folder chooser** over the host, or lets you type a local path → adopted directly as a normal DSH local workspace (local workspaces fully coexist).
-  - **远程 / Remote** — the picker is a **centered modal** (never squeezed into a narrow sidebar). Pick a **machine** → the path field is **pre-filled with `/`** and live **autocompletes** directories; **selecting a directory immediately lists its next level** (OS/VSCode-style cascade). A **浏览…** floating browser (opaque, height-capped, scrollable, follows symlinks) fills the field without committing — you review, edit, then confirm. On confirm it creates a **real local mirror** (`~/.dsh/remote-workspaces/<host>/<base>-<hash>`) that passes `fs.realpath` → the harness adopts it as a real workspace while dsh-remote keeps it synced over SFTP.
-- **Bidirectional SFTP sync** — `rw_sync` (remote → mirror) and `rw_push` (mirror → remote) round-trip your local-mirror edits back to the machine.
-- **Model tools** — `rw_info`, `rw_connect`, `rw_pick_workspace`, `rw_list_dir`, `rw_read_file`, `rw_write_file`, `rw_exec`, `rw_sync`, `rw_push`, `rw_disconnect`.
-- **Write directly to a remote file** — `rw_write_file` creates or overwrites a remote file (making parent directories), so you don't have to round-trip through a local mirror for a single-file edit.
+  - **本机 / Local** — opens the **native OS folder chooser** over the host, or lets you type a local path → adopted directly as a normal DSH local workspace (local workspaces fully coexist). The chooser uses the DSH `directoryPicker` service when available and otherwise falls back to the plugin's own native picker (macOS `osascript` / Linux `zenity`→`kdialog`) — so it works even when the framework service isn't registered on the desktop boot path.
+  - **远程 / Remote** — the picker is a **centered modal** (never squeezed into a narrow sidebar). Pick a **machine** → the path field is **pre-filled with `/`** and live **autocompletes** directories; **selecting a directory immediately lists its next level** (OS/VSCode-style cascade). A **浏览…** floating browser (opaque, height-capped, scrollable, follows symlinks) fills the field without committing — you review, edit, then confirm. On confirm it creates a **real local mirror** under `$DSH_HOME/remote-workspaces/<host>-<user>-<port>/<base>` (a short path-hash is appended only when a different remote path already took the same basename) that passes `fs.realpath` → the harness adopts it as a real workspace while dsh-remote keeps it synced over SFTP. The chosen workspace is persisted on the machine, so it survives restarts.
+- **Bidirectional SFTP sync** — `rw_sync` (remote → mirror) and `rw_push` (mirror → remote) round-trip your local-mirror edits back to the machine. Both are **incremental**: files whose size + mtime already match are skipped, and a per-file size cap prevents accidental big-binary downloads. Directory sweeps run with bounded parallelism.
+- **Model tools** — `rw_info`, `rw_connect`, `rw_pick_workspace`, `rw_list_dir`, `rw_read_file`, `rw_write_file`, `rw_exec` (runs in the current workspace by default, or `cwd=<path>`), `rw_search` (portable recursive grep), `rw_download`, `rw_upload`, `rw_sync`, `rw_push`, `rw_disconnect`.
+- **Write directly to a remote file** — `rw_write_file` creates or overwrites a remote file (making parent directories), so you don't have to round-trip through a local mirror for a single-file edit. `rw_download` / `rw_upload` move a single file either way when you need the real bytes.
 - **Connection health** — a **「测试连接」 test-connection** button in the Settings page validates host/user/key/password before you save a machine.
 - The active `user@host:/path` is injected into every system prompt so the agent knows its working root.
 - **No official `dsh-workspace` core is modified** — everything is delivered as a normal plugin (directory-flow holes filled by the client half at `priority -100`).
+- **Cross-platform remotes** — commands use portable POSIX forms (`ls -la`, `sed -n`, `find … -exec grep`), so the same plugin works against macOS/BSD as well as GNU/Linux hosts.
+- **Host-key verification (TOFU)** — every SSH connect verifies the host key
+  (`hostKeyMode: accept-new`): first connect records it, a later CHANGE is rejected
+  as a possible man-in-the-middle. `verify` also refuses hosts never seen before;
+  `off` disables it. Stored at `$DSH_HOME/remote-workspaces/known_hosts.json`; reset
+  with `/remote forget-key`.
+- **Data lives under the harness home** — machines + mirrors follow `$DSH_HOME` (the desktop app sets it to its own `userData/harness`); pre-0.6 data under `~/.dsh/remote-workspaces` is migrated automatically on first run.
 
 ## Install
 
@@ -60,7 +67,8 @@ dsh plugin add dsh-remote            # add the bundle
 3. **Work with the agent** — treat it like any workspace:
    - `rw_list_dir(path?)`/`rw_read_file` — inspect remote files
    - `rw_write_file(path, content)` — create or overwrite a remote file directly
-   - `rw_exec(command)` — run remote shell commands
+   - `rw_search(pattern, path?)` — grep remote files
+   - `rw_exec(command, cwd?)` — run remote shell commands (defaults to the workspace dir)
    - `rw_sync` / `rw_push` — pull/push the local mirror to and from the remote
 
 ## CLI defaults (optional)
@@ -107,6 +115,38 @@ npx --yes @deepseek-ai/dsh plugin --profile web remove dsh-remote   # back to re
 
 After a successful start, `Settings → 远程工作区` appears and the "Add workspace" flow gains the 本机 / 远程 tabs (screenshots above).
 
+## Development (sandbox, not product)
+
+Iterate **in the sandbox**, never by hand-editing a product profile — the
+product profile is re-managed by the plugin manager and reverts hand-deployed
+files on reinstall. Use the helper script:
+
+```bash
+scripts/dev-run.sh --restart   # start / restart the isolated sandbox
+scripts/dev-run.sh --stop      # stop it
+scripts/dev-run.sh --status    # is it running?
+```
+
+- Runs its own DSH instance (`dev-harness/harness` inside this repo) with the
+  plugin copied in from `lib/` — it boots through the same `bin.js web --patch`
+  path as the desktop app, so the sandbox reproduces the product boot behavior.
+- The sandbox web UI serves on `http://127.0.0.1:50599` and the plugin routes
+  are live immediately (e.g. `GET /dsh-remote/machines`).
+- **Host-half changes** (`lib/index.js`) need a sandbox restart (`--restart`);
+  **client-half changes** (`lib/client.js`) need a page refresh.
+- Node ESM resolves dependencies from the importing file's real path, so the
+  script **copies** `lib/` (hardlink copy, `cp -al`) into the sandbox profile
+  instead of symlinking — a symlink breaks `@deepseek-ai/*` resolution.
+- Run `scripts/check.mjs` (static framework-constraint gate: command-name
+  regex, …) before every commit; `scripts/boot-smoke.sh` boots an isolated
+  instance to prove the plugin still starts.
+- Full rules live in `scripts/dev-standards.md` (command names, cordis service
+  access via `ctx.get()` only, optional framework services may never register,
+  verify third-party callback contracts against the real runtime, …).
+
+Deploying to a product profile is a separate, explicit action (`./sync.sh`)
+and should be done only when you intend to release.
+
 ## Configuration
 
 | Key | Type | Default | Meaning |
@@ -115,10 +155,12 @@ After a successful start, `Settings → 远程工作区` appears and the "Add wo
 | `port` | int | `22` | default SSH port |
 | `username` | string | `''` | default SSH user |
 | `password` | string | `''` | default SSH password (non-empty overrides key) |
-| `privateKeyPath` | string | `''` | private key path (`~/.ssh/id_rsa` when empty) |
+| `privateKeyPath` | string | `''` | private key path (used only when explicitly provided) |
 | `workspace` | string | `''` | default remote workspace path |
 | `commandTimeoutMs` | int | 20000 | per remote command timeout |
 | `connectTimeoutMs` | int | 15000 | SSH connect timeout |
+| `maxFileBytes` | int | 52428800 | skip mirroring files larger than this (0 = no cap) |
+| `hostKeyMode` | string | `accept-new` | host-key policy: `accept-new` (TOFU), `verify` (reject unknown hosts), `off` (skip) |
 
 ## Safety
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -34,13 +34,16 @@ DSH 的 Web 界面刻意只监听 `127.0.0.1`（CLI 为安全拒绝 `--host 0.0.
 
 - **多机 SSH** —— 可存任意多台主机（host/port/user + **私钥**或**密码**）。密码只存在本地，界面不回显；在设置里一键切当前机。
 - **双 tab 工作区选择器**（填充原生「Add workspace」流程）：
-  - **本机** —— 走 **host 端原生系统文件夹对话框**选本地目录（或直接输入本地路径）→ 直接成为普通 DSH 本地工作区（与本地工作区共存）。
-  - **远程** —— 选择器是**居中弹窗**（窄侧边栏也不会被挤压）。先**选机器** → 路径框**自动预填 `/`** 并**实时补全**目录；**选中一个目录立即列出它下一级**（OS/VSCode 式级联）。另有 **「浏览…」浮层**（不透明、定高、内部滚动、跟随软链），选中**回填输入框不提交**，你复核/修改后再确定。确定会创建**真实本地镜像**（`~/.dsh/remote-workspaces/<host>/<basename>-<hash>`，`fs.realpath` 通过）→ harness 把它当真实工作区收养，同时 dsh-remote 通过 SFTP 保持同步。
-- **双向 SFTP 同步** —— `rw_sync`（远程→镜像）、`rw_push`（镜像→远程），本地镜像改动可回传机器。
-- **模型工具** —— `rw_info`、`rw_connect`、`rw_pick_workspace`、`rw_list_dir`、`rw_read_file`、`rw_write_file`、`rw_exec`、`rw_sync`、`rw_push`、`rw_disconnect`。
-- **直接写远程文件** —— `rw_write_file` 直接创建/覆盖远程文件（自动建父目录），单个文件改动不必绕本地镜像来回同步。
+  - **本机** —— 走 **host 端原生系统文件夹对话框**选本地目录（或直接输入本地路径）→ 直接成为普通 DSH 本地工作区（与本地工作区共存）。优先用 DSH 的 `directoryPicker` 服务，服务缺失时**回退到插件自持的原生选择器**（macOS `osascript` / Linux `zenity`→`kdialog`）——桌面启动路径上框架服务不注册也能用。
+  - **远程** —— 选择器是**居中弹窗**（窄侧边栏也不会被挤压）。先**选机器** → 路径框**自动预填 `/`** 并**实时补全**目录；**选中一个目录立即列出它下一级**（OS/VSCode 式级联）。另有 **「浏览…」浮层**（不透明、定高、内部滚动、跟随软链），选中**回填输入框不提交**，你复核/修改后再确定。确定会创建**真实本地镜像**（`$DSH_HOME/remote-workspaces/<host>-<user>-<port>/<basename>`；仅当同主机上**别的远端路径**已占用同名 basename 时才追加短路径 hash）→ harness 把它当真实工作区收养，同时 dsh-remote 通过 SFTP 保持同步。所选工作区会**持久化到该机器**，重启不丢。
+- **双向 SFTP 同步（增量）** —— `rw_sync`（远程→镜像）、`rw_push`（镜像→远程），本地镜像改动可回传机器。两者都会**跳过 size+mtime 未变化的文件**，并有**单文件大小上限**防误拉大二进制；目录遍历带**有界并发**。
+- **模型工具** —— `rw_info`、`rw_connect`、`rw_pick_workspace`、`rw_list_dir`、`rw_read_file`、`rw_write_file`、`rw_exec`（默认在工作区目录执行，可传 `cwd=`）、`rw_search`（可移植递归 grep）、`rw_download`、`rw_upload`、`rw_sync`、`rw_push`、`rw_disconnect`。
+- **直接写远程文件** —— `rw_write_file` 直接创建/覆盖远程文件（自动建父目录），单个文件改动不必绕本地镜像来回同步；`rw_download` / `rw_upload` 可单文件双向取真字节。
 - **连接体检** —— 设置页提供「测试连接」按钮，在保存机器之前先验证 host/user/密码/私钥是否可用。
 - 当前 `user@host:/path` 会注入每次系统提示，让 Agent 明确自己的工作根。
+- **远端跨平台** —— 命令全部用可移植 POSIX 写法（`ls -la` / `sed -n` / `find … -exec grep`），macOS/BSD 与 GNU/Linux 远端都能用。
+- **主机指纹校验（TOFU）** —— 每次 SSH 连接都校验主机密钥（`hostKeyMode: accept-new`）：首次连接记录，之后**密钥一旦变化立即拒绝**（防中间人）。`verify` 模式还会拒绝从未见过的机器；`off` 关闭校验。指纹存于 `$DSH_HOME/remote-workspaces/known_hosts.json`；误判可用 `/remote forget-key` 重置。
+- **数据跟随 Harness 根目录** —— 机器清单与镜像放在 `$DSH_HOME/remote-workspaces`（桌面版即 `userData/harness` 下）；0.6 之前落在 `~/.dsh/remote-workspaces` 的数据**首次启动自动迁移**，不丢失。
 - **不改任何 `dsh-workspace` 官方代码** —— 全部作为普通插件实现（client 半以 `priority -100` 填充 directory-flow holes）。
 
 ## 安装
@@ -60,7 +63,8 @@ dsh plugin add dsh-remote            # 添加 bundle
 3. **让 Agent 工作** —— 把它当普通工作区用：
    - `rw_list_dir(path?)` / `rw_read_file` —— 查看远程文件
    - `rw_write_file(path, content)` —— 直接创建或覆盖远程文件
-   - `rw_exec(command)` —— 在远程执行命令
+   - `rw_search(pattern, path?)` —— 远程 grep
+   - `rw_exec(command, cwd?)` —— 在远程执行命令（默认在工作区目录）
    - `rw_sync` / `rw_push` —— 拉取/推送本地镜像 <-> 远程
 
 ## 可选：CLI 默认机
@@ -108,6 +112,32 @@ npx --yes @deepseek-ai/dsh plugin --profile web remove dsh-remote   # 恢复用�
 
 启动成功后，设置 →「远程工作区」会出现；「Add workspace」流程会带「本机 / 远程」两个 tab（见上方效果图）。
 
+## 开发（沙箱优先，勿改产品）
+
+迭代**一律在沙箱**里做，绝不手工改产品 profile——产品 profile 由插件管理器重管，
+重装会把手工部署的文件还原掉。用仓库内的辅助脚本：
+
+```bash
+scripts/dev-run.sh --restart   # 启动 / 重启隔离沙箱
+scripts/dev-run.sh --stop      # 停止
+scripts/dev-run.sh --status    # 是否在运行
+```
+
+- 自带一套独立 DSH 实例（仓库内 `dev-harness/harness`），把 `lib/` 复制进沙箱
+  profile——与桌面 App 走同一条 `bin.js web --patch` 启动路径，沙箱即产品启动行为。
+- 沙箱 web UI 在 `http://127.0.0.1:50599`，插件路由立即可见（如
+  `GET /dsh-remote/machines`）。
+- **宿主半改动**（`lib/index.js`）需重启沙箱（`--restart`）；**客户端半改动**
+  （`lib/client.js`）只需刷新页面。
+- Node ESM 按导入文件的真实路径解析依赖，脚本用**硬链接拷贝**（`cp -al`）把
+  `lib/` 复制进沙箱 profile，而不是软链——软链会破坏 `@deepseek-ai/*` 的解析。
+- 每次提交前跑 `scripts/check.mjs`（静态框架约束闸门：命令名正则等）；
+  `scripts/boot-smoke.sh` 用隔离实例证明插件仍能启动。
+- 完整规则见 `scripts/dev-standards.md`（命令名、cordis 服务只许 `ctx.get()`、
+  可选框架服务可能压根不注册、三方库回调契约以真实运行为准等）。
+
+部署到产品 profile 是单独的受控动作（`./sync.sh`），只在确定要发布时做。
+
 ## 配置
 
 | 键 | 类型 | 默认 | 说明 |
@@ -116,10 +146,12 @@ npx --yes @deepseek-ai/dsh plugin --profile web remove dsh-remote   # 恢复用�
 | `port` | int | `22` | 默认 SSH 端口 |
 | `username` | string | `''` | 默认 SSH 用户 |
 | `password` | string | `''` | 默认 SSH 密码（非空覆盖 key） |
-| `privateKeyPath` | string | `''` | 私钥路径（空=`~/.ssh/id_rsa`） |
+| `privateKeyPath` | string | `''` | 私钥路径（仅在显式提供时使用） |
 | `workspace` | string | `''` | 默认远程工作区路径 |
 | `commandTimeoutMs` | int | 20000 | 单条远程命令超时 |
 | `connectTimeoutMs` | int | 15000 | SSH 连接超时 |
+| `maxFileBytes` | int | 52428800 | 镜像同步时跳过超过该大小的文件（0=不设上限） |
+| `hostKeyMode` | string | `accept-new` | 主机指纹策略：`accept-new`（首次信任）、`verify`（拒绝未知主机）、`off`（跳过校验） |
 
 ## 安全提醒
 

--- a/check.mjs
+++ b/check.mjs
@@ -1,0 +1,52 @@
+// dsh-remote 部署前闸门（Pre-deploy gate）
+//
+// 在 ./sync.sh 部署前运行，拦截会"把自己搞崩"的源码问题。历史教训：
+// v0.6.1 曾把 slash 命令命名为 `remote.forget-key`，而 dsh-commands 框架
+// 硬校验命令名必须匹配 /^[a-z][a-z0-9_-]*$/u（不允许点号/大写/空格），
+// 导致插件树加载失败、整个 DSH Desktop 无法启动，直到手工修复。
+//
+// 本脚本是纯文本静态检查（不 import 模块，无需依赖即可运行），只查那些
+// 违反会让 boot 崩溃的"框架注册约束"。语法问题由 node --check 兜底，
+// 真正的启动冒烟测试见 scripts/boot-smoke.sh。
+import { readFileSync } from 'node:fs'
+import { fileURLToPath } from 'node:url'
+import path from 'node:path'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const src = readFileSync(path.join(here, 'lib', 'index.js'), 'utf8')
+const file = path.relative(process.cwd(), path.join(here, 'lib', 'index.js'))
+
+let fail = 0
+
+// ── 1) slash 命令名必须匹配 dsh-commands 的约束 ───────────────────────────
+// 依据：安装框架 @deepseek-ai/dsh-commands lib/index.js normalizeDefinition()
+const COMMAND_NAME = /^[a-z][a-z0-9_-]*$/u
+const regRe = /commands\.register\(\s*\{[\s\S]*?\bname:\s*'([^']+)'/g
+let m, total = 0
+while ((m = regRe.exec(src))) {
+  total++
+  if (!COMMAND_NAME.test(m[1])) {
+    fail++
+    console.log(`  ✗ ${file}:${lineOf(src, m.index)}: command name '${m[1]}' must match ${COMMAND_NAME} (no dots/uppercase/spaces)`)
+  }
+}
+console.log(`  command-name lint: ${total} register(s) checked`)
+
+// ── 2) 常见 boot 崩溃点：禁止点号注册名（其它 register 也套同正则，防类名误用）──
+const otherRe = /\.register\(\{\s*name:\s*'([^']*)'[\s\S]*?\b(?:route|event|service)\b/g
+while ((m = otherRe.exec(src))) {
+  if (!COMMAND_NAME.test(m[1])) {
+    fail++
+    console.log(`  ✗ ${file}:${lineOf(src, m.index)}: suspicious dotted/illegal registration name '${m[1]}'`)
+  }
+}
+
+function lineOf(text, idx) {
+  return text.slice(0, idx).split('\n').length
+}
+
+if (fail) {
+  console.error(`\ncheck.mjs FAILED: ${fail} problem(s). 修复后再部署。`)
+  process.exit(1)
+}
+console.log('check.mjs OK: no framework-constraint violations.')

--- a/lib/client.js
+++ b/lib/client.js
@@ -200,14 +200,14 @@ window.__ModuleLoader__.load({
       const [suggestOpen, setSuggestOpen] = React.useState(false)
       const suggestTimer = React.useRef(null)
       const suggestRef = React.useRef(null)
-      // 点击候选路径下拉外部的空白处时，收起自动补全列表
+      // 点击自动补全下拉外部的空白处时收起补全列表（上游 0.5.10）
       React.useEffect(() => {
         if (!suggestOpen) return
         const onDown = (ev) => { if (suggestRef.current && !suggestRef.current.contains(ev.target)) setSuggestOpen(false) }
         document.addEventListener('mousedown', onDown)
         return () => document.removeEventListener('mousedown', onDown)
       }, [suggestOpen])
-      // 机器下拉：点外部任意处关闭，避免候选层常驻遮挡下方按钮
+      // 机器下拉（自绘 dropdown）：点外部任意处关闭，避免候选层常驻遮挡下方按钮（上游 0.5.8）
       const [mOpen, setMOpen] = React.useState(false)
       const ddRef = React.useRef(null)
       React.useEffect(() => {
@@ -414,13 +414,13 @@ window.__ModuleLoader__.load({
               React.createElement('div', { style: { display: 'flex', gap: 6, alignItems: 'center' } },
                 React.createElement('label', { style: { fontSize: 12, opacity: 0.8, whiteSpace: 'nowrap' } }, '远程机器:'),
                 React.createElement('div', { ref: ddRef, style: { position: 'relative', display: 'inline-block' } },
-                  React.createElement('button', { style: { ...inputS, textAlign: 'left', cursor: 'pointer', minWidth: 200, maxWidth: 320, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }, onClick: () => setMOpen((v) => !v) },
+                  React.createElement('button', { style: { ...inputS, textAlign: 'left', cursor: 'pointer', minWidth: 200, maxWidth: 320, overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }, onClick: () => setMOpen((x) => !x) },
                     (machines.find((m) => m.id === machineId) || {}).name || (machineId ? '…' : '— 选择机器 —'),
                   ),
                   mOpen
-                    ? React.createElement('div', { style: { position: 'absolute', top: '100%', left: 0, zIndex: 1000, marginTop: 2, minWidth: 300, maxHeight: 260, overflow: 'auto', background: '#1f1f23', border: '1px solid ' + T.border, borderRadius: T.radius, padding: 4 } },
+                    ? React.createElement('div', { style: { position: 'absolute', top: '100%', left: 0, zIndex: 1000, marginTop: 2, minWidth: 300, maxHeight: 260, overflow: 'auto', background: v('--dsw-alias-bg-overlay', '#1f1f23'), border: '1px solid ' + T.border, borderRadius: T.radius, padding: 4 } },
                         machines.length
-                          ? machines.map((m) => React.createElement('div', { key: m.id, onClick: () => { setMachineId(m.id); setLevels(null); if (m.id) { loadLevels(m.id, '', 0); if (!path.trim()) { setPath('/'); loadSuggestions('/', m.id) } } setMOpen(false) }, style: { padding: '6px 8px', borderRadius: 4, cursor: 'pointer', color: m.id === machineId ? T.ok : 'inherit' } }, m.name + '  (' + m.username + '@' + m.host + ':' + m.port + ')'))
+                          ? machines.map((m) => React.createElement('div', { key: m.id, onClick: () => { setMachineId(m.id); setLevels(null); setMOpen(false); if (m.id) { loadLevels(m.id, '', 0); if (!path.trim()) { setPath('/'); loadSuggestions('/', m.id) } } }, style: { padding: '6px 8px', borderRadius: 4, cursor: 'pointer', color: m.id === machineId ? T.ok : 'inherit' } }, m.name + '  (' + m.username + '@' + m.host + ':' + m.port + ')'))
                           : React.createElement('div', { style: { padding: 6, opacity: 0.6 } }, '还没有机器，请先在设置里添加'),
                       )
                     : null,

--- a/lib/index.js
+++ b/lib/index.js
@@ -18,7 +18,9 @@
 import z from '@deepseek-ai/schemastery'
 import { defineTool } from '@deepseek-ai/dsh-tools'
 import ssh2 from 'ssh2'
-import { readFileSync, mkdirSync, writeFileSync, existsSync, readdirSync, statSync } from 'node:fs'
+import { createHash } from 'node:crypto'
+import { execFile } from 'node:child_process'
+import { readFileSync, mkdirSync, writeFileSync, existsSync, readdirSync, statSync, renameSync, copyFileSync, utimesSync } from 'node:fs'
 import { homedir } from 'node:os'
 import path from 'node:path'
 
@@ -53,6 +55,13 @@ export const Config = z.object({
   connectTimeoutMs: z.number().step(1).min(1000).default(15000),
   /** Hard ceiling on collected remote output per call. */
   maxOutputChars: z.number().step(1).min(1024).default(200000),
+  /** Skip mirroring files larger than this many bytes (0 = no cap). */
+  maxFileBytes: z.number().step(1).min(0).default(52428800),
+  /** Host-key policy: `accept-new` (default) records a host's key on first
+   * connect and verifies it afterwards (mirrors ssh's StrictHostKeyChecking
+   * accept-new); `verify` also rejects hosts never seen before; `off` skips
+   * verification entirely (MITM-unsafe, not recommended). */
+  hostKeyMode: z.string().default('accept-new'),
 })
 
 // ── shell / path helpers (proven in the read tooling) ───────────────────────
@@ -100,18 +109,89 @@ const remotePathBase = (p) => {
   return base || 'workspace'
 }
 
+/** Harness home: respect `DSH_HOME` when set (the desktop app sets it to its
+ * own `userData/harness`), otherwise fall back to `~/.dsh`. Keeping plugin
+ * data under the same root the harness uses means uninstalling / upgrading the
+ * app no longer leaves state behind in the home directory. */
+function dshBase() {
+  const env = process.env.DSH_HOME
+  if (env && String(env).trim()) return path.resolve(String(env).trim())
+  return path.join(homedir(), '.dsh')
+}
+
+/** Root holding every remote host's mirrors + the machine registry. */
+function remoteWorkspacesRoot() {
+  return path.join(dshBase(), 'remote-workspaces')
+}
+
+/** Recursive directory copy (EXDEV fallback for migrateLegacyData). */
+function copyDirSync(from, to) {
+  mkdirSync(to, { recursive: true })
+  for (const e of readdirSync(from, { withFileTypes: true })) {
+    const s = path.join(from, e.name)
+    const d = path.join(to, e.name)
+    if (e.isDirectory()) copyDirSync(s, d)
+    else try { copyFileSync(s, d) } catch { /* skip unreadable */ }
+  }
+}
+
+/** One-time migration of pre-0.6 data (which lived at `~/.dsh/remote-workspaces`
+ * regardless of `DSH_HOME`). Moves the legacy dir into the current home so a
+ * desktop install keeps its existing machines and mirrors. Idempotent; a
+ * rename across devices falls back to a copy. */
+function migrateLegacyData() {
+  const legacy = path.join(homedir(), '.dsh', 'remote-workspaces')
+  const target = remoteWorkspacesRoot()
+  if (legacy === target || !existsSync(legacy) || existsSync(target)) return
+  try {
+    mkdirSync(path.dirname(target), { recursive: true })
+    try {
+      renameSync(legacy, target)
+    } catch (err) {
+      if (err.code !== 'EXDEV') throw err
+      copyDirSync(legacy, target)
+    }
+  } catch {
+    // Migration is best-effort: a fresh registry is created on next save.
+  }
+}
+
+/** 32-bit string hash rendered in base36 (short, collision-safe enough). */
+function shortHash(s) {
+  let h = 0
+  for (let i = 0; i < s.length; i++) {
+    h = ((h << 5) - h + s.charCodeAt(i)) | 0
+  }
+  return (h >>> 0).toString(36)
+}
+
 /** Stable local root for one remote host's mirrors */
 function mirrorRootFor(host, user, port) {
   const tag = [host, user, port].filter(Boolean).join('-').replace(/[^a-zA-Z0-9._-]/g, '_')
-  return path.join(homedir(), '.dsh', 'remote-workspaces', tag)
+  return path.join(remoteWorkspacesRoot(), tag)
 }
 
 /** Local mirror dir for a specific remote path (idempotent → returns same dir).
  * Named after the remote directory's basename so the harness workspace label
- * reads cleanly (e.g. .../project) instead of a concatenated hash string. */
+ * reads cleanly (e.g. .../project). When the plain basename dir is already
+ * taken by a DIFFERENT remote path on the same host, a short path-hash suffix
+ * is appended so mirrors never collide. */
 function mirrorDirFor(remotePath, host, user, port) {
   const base = remotePathBase(remotePath)
-  return path.join(mirrorRootFor(host, user, port), base)
+  const root = mirrorRootFor(host, user, port)
+  const plain = path.join(root, base)
+  const norm = normalizeRemotePath(remotePath)
+  // A pre-existing mirror for this exact remote origin → reuse it (idempotent).
+  try {
+    const meta = JSON.parse(readFileSync(path.join(plain, '.dsh-remote-meta.json'), 'utf8'))
+    if (meta.remotePath === norm) return plain
+  } catch {
+    /* no mirror yet → fall through */
+  }
+  // Plain dir is free → first mirror for this basename keeps the clean name.
+  // It exists but points elsewhere (or is a non-mirror dir) → hashed variant.
+  if (!existsSync(plain)) return plain
+  return path.join(root, base + '-' + shortHash(norm))
 }
 
 /** Create the local mirror dir + a meta file describing its remote origin. */
@@ -120,82 +200,130 @@ function ensureMirror(remotePath, host, user, port) {
   mkdirSync(dir, { recursive: true })
   writeFileSync(
     path.join(dir, '.dsh-remote-meta.json'),
-    JSON.stringify({ host, port, username: user, remotePath, createdAt: new Date().toISOString() }, null, 2),
+    JSON.stringify({ host, port, username: user, remotePath: normalizeRemotePath(remotePath), createdAt: new Date().toISOString() }, null, 2),
   )
   return dir
 }
 
-/** Recursively sync remote → local mirror. Bounded by depth/files. */
-async function syncTree(sftp, remoteDir, localDir, maxDepth, maxFiles) {
+/** Run `fn` over `items` with at most `limit` concurrent in-flight calls. */
+async function mapLimit(items, limit, fn) {
+  const limitN = Math.max(1, Math.min(Math.floor(limit) || 1, items.length))
+  let next = 0
+  const worker = async () => {
+    while (next < items.length) {
+      const i = next++
+      try { await fn(items[i], i) } catch { /* per-item errors are the fn's concern */ }
+    }
+  }
+  const workers = []
+  for (let w = 0; w < limitN; w++) workers.push(worker())
+  await Promise.all(workers)
+}
+
+/** Recursively sync remote → local mirror. Bounded by depth/files/size;
+ * skips files whose size+mtime already match locally. Returns counters. */
+async function syncTree(sftp, remoteDir, localDir, maxDepth, maxFiles, maxFileBytes) {
   const entries = await sftp.readdir(remoteDir).then(
     (list) => list,
     () => [],
   )
-  let files = 0
-  const touched = []
+  const stats = { files: 0, dirs: 0, skippedUnchanged: 0, skippedLarge: 0, touched: [] }
+
+  // Directories first (sequential, depth-bounded) so every file has a home.
   for (const e of entries) {
     const name = String(e.filename)
     if (name === '.' || name === '..') continue
+    const isDir = e.attrs && e.attrs.isDirectory && e.attrs.isDirectory()
+    if (!isDir) continue
+    if (maxDepth <= 0 || stats.files >= maxFiles) continue
     const rp = remoteDir === '/' ? '/' + name : remoteDir + '/' + name
     const lp = path.join(localDir, name)
-    const isDir = e.attrs && e.attrs.isDirectory && e.attrs.isDirectory()
-    if (isDir) {
-      if (maxDepth <= 0) continue
-      mkdirSync(lp, { recursive: true })
-      const sub = await syncTree(sftp, rp, lp, maxDepth - 1, maxFiles)
-      files += sub.files
-      touched.push(...sub.touched)
-      continue
-    }
-    if (files >= maxFiles) break
+    mkdirSync(lp, { recursive: true })
+    const sub = await syncTree(sftp, rp, lp, maxDepth - 1, maxFiles - stats.files, maxFileBytes)
+    stats.dirs += sub.dirs + 1
+    stats.files += sub.files
+    stats.skippedUnchanged += sub.skippedUnchanged
+    stats.skippedLarge += sub.skippedLarge
+    stats.touched.push(...sub.touched)
+    if (stats.files >= maxFiles) break
+  }
+  if (stats.files >= maxFiles) return stats
+
+  // Files in one bounded-parallel sweep per directory level.
+  const fileEntries = entries.filter(
+    (e) => !(e.attrs && e.attrs.isDirectory && e.attrs.isDirectory()) &&
+      String(e.filename) !== '.' && String(e.filename) !== '..',
+  )
+  await mapLimit(fileEntries, 4, async (e) => {
+    if (stats.files >= maxFiles) return
+    const name = String(e.filename)
+    const rp = remoteDir === '/' ? '/' + name : remoteDir + '/' + name
+    const lp = path.join(localDir, name)
     try {
+      const st = await sftp.stat(rp)
+      if (maxFileBytes > 0 && st.size > maxFileBytes) { stats.skippedLarge++; return }
+      const lpStat = existsSync(lp) ? statSync(lp) : null
+      const unchanged = lpStat && lpStat.size === st.size && Math.floor(lpStat.mtimeMs / 1000) === st.mtime
+      if (unchanged) { stats.skippedUnchanged++; return }
       const buf = await sftp.readFile(rp)
       writeFileSync(lp, buf)
-      touched.push(rp)
-      files++
+      try { utimesSync(lp, new Date(st.mtime * 1000), new Date(st.mtime * 1000)) } catch {}
+      stats.files++
+      stats.touched.push(rp)
     } catch {
       /* skip unreadable */
     }
-  }
-  return { files, touched }
+  })
+  return stats
 }
 
-/** Recursively upload a local mirror tree → remote SFTP dir. Bounded by files. */
-async function pushTree(sftp, localDir, remoteDir, remoteBaseDir, maxFiles) {
+/** Recursively upload a local mirror tree → remote SFTP dir. Bounded by files;
+ * skips files whose remote copy already matches (same size, remote no older). */
+async function pushTree(sftp, localDir, remoteDir, maxFiles, maxFileBytes) {
   const entries = readdirSync(localDir, { withFileTypes: true }).filter((e) => e.name !== '.dsh-remote-meta.json')
-  let files = 0
-  let dirsCreated = 0
-  const pushed = []
+  const stats = { files: 0, dirs: 0, skippedUnchanged: 0, skippedLarge: 0, pushed: [] }
+
   for (const e of entries) {
-    if (e.isDirectory()) {
-      const rp = remoteDir === '/' ? '/' + e.name : remoteDir + '/' + e.name
-      try {
-        await sftp.mkdir(rp)
-        dirsCreated++
-      } catch { /* already exists */ }
-      const sub = await pushTree(sftp, path.join(localDir, e.name), rp, remoteBaseDir, maxFiles)
-      files += sub.files
-      pushed.push(...sub.pushed)
-      continue
-    }
-    if (files >= maxFiles) break
+    if (!e.isDirectory()) continue
+    if (stats.files >= maxFiles) break
+    const rp = remoteDir === '/' ? '/' + e.name : remoteDir + '/' + e.name
+    try { await sftp.mkdir(rp) } catch { /* already exists */ }
+    stats.dirs++
+    const sub = await pushTree(sftp, path.join(localDir, e.name), rp, maxFiles - stats.files, maxFileBytes)
+    stats.files += sub.files
+    stats.skippedUnchanged += sub.skippedUnchanged
+    stats.skippedLarge += sub.skippedLarge
+    stats.pushed.push(...sub.pushed)
+    if (stats.files >= maxFiles) break
+  }
+  if (stats.files >= maxFiles) return stats
+
+  const fileEntries = entries.filter((e) => !e.isDirectory())
+  await mapLimit(fileEntries, 4, async (e) => {
+    if (stats.files >= maxFiles) return
     const lp = path.join(localDir, e.name)
     const rp = remoteDir === '/' ? '/' + e.name : remoteDir + '/' + e.name
     try {
+      const lstat = statSync(lp)
+      if (maxFileBytes > 0 && lstat.size > maxFileBytes) { stats.skippedLarge++; return }
+      let rstat = null
+      try { rstat = await sftp.stat(rp) } catch { /* remote file absent → upload */ }
+      const unchanged = rstat && rstat.size === lstat.size && rstat.mtime >= Math.floor(lstat.mtimeMs / 1000)
+      if (unchanged) { stats.skippedUnchanged++; return }
       const buf = readFileSync(lp)
       await sftp.writeFile(rp, buf)
-      pushed.push(rp)
-      files++
+      stats.files++
+      stats.pushed.push(rp)
     } catch {
       /* skip unreadable / unwritable */
     }
-  }
-  return { files, pushed }
+  })
+  return stats
 }
 
 // ── persistent multi-machine registry ─────────────────────────────────────
 const MACHINES_FILE = 'machines.json'
-const machinesFile = () => path.join(homedir(), '.dsh', 'remote-workspaces', MACHINES_FILE)
+const machinesFile = () => path.join(remoteWorkspacesRoot(), MACHINES_FILE)
 function loadMachines() {
   try {
     const j = JSON.parse(readFileSync(machinesFile(), 'utf8'))
@@ -225,6 +353,98 @@ function applyMachine(config, m) {
 }
 function machineId() { return 'm-' + Date.now().toString(36) + '-' + Math.random().toString(36).slice(2, 6) }
 
+// ── host-key registry (TOFU: trust-on-first-use, like ssh accept-new) ──────
+const KNOWN_HOSTS_FILE = 'known_hosts.json'
+const knownHostsFile = () => path.join(remoteWorkspacesRoot(), KNOWN_HOSTS_FILE)
+
+/** Read the trusted host-key map { "host:port": { algo, fingerprint } }. */
+function loadKnownHosts() {
+  try {
+    const j = JSON.parse(readFileSync(knownHostsFile(), 'utf8'))
+    if (j && typeof j === 'object' && !Array.isArray(j)) return j
+  } catch {}
+  return {}
+}
+
+/** Extract the host-key algorithm name from a raw SSH host-key blob
+ * (SSH wire format: `uint32 len` + algorithm string + key data). */
+function blobAlgorithm(blob) {
+  if (!Buffer.isBuffer(blob) || blob.length < 4) return ''
+  try {
+    const len = blob.readUInt32BE(0)
+    return blob.toString('utf8', 4, 4 + len)
+  } catch {
+    return ''
+  }
+}
+
+/** SHA-256 fingerprint (base64) of an ssh2 host-key blob, like `SHA256:…`
+ * in a known_hosts file (without the `SHA256:` prefix).
+ *
+ * ssh2 v1.17 passes hostVerifier the RAW host-key blob Buffer (the SSH
+ * wire-format `string(algo) string(keydata)`), NOT the old `{ algo, hash }`
+ * object. Fingerprinting `key.hash` on a raw Buffer crashed with "The 'data'
+ * argument must be of type string or an instance of Buffer, TypedArray, or
+ * DataView. Received undefined" on EVERY connect (v0.6.6 bug) — so the
+ * v0.6.1 TOFU guard never actually worked against real ssh2. Accept both
+ * shapes defensively. */
+function keyFingerprint(key) {
+  const blob = Buffer.isBuffer(key) ? key : (key && key.hash)
+  if (!blob) throw new Error('host key missing (hostVerifier received no key blob)')
+  return createHash('sha256').update(blob).digest('base64')
+}
+
+/** Build an ssh2 `hostVerifier` bound to the current config. Returns
+ * `{ mode, verifier, lastError, knownHosts, forgetHost }`. The verifier:
+ *  - `off` → always accepts;
+ *  - `accept-new` → records a host's key on first connect, rejects any CHANGE
+ *    afterwards (classic TOFU / MITM detection);
+ *  - `verify` → same, plus rejects hosts never recorded before. */
+function createHostKeyGuard(config) {
+  const id = () => `${config.host}:${config.port}`
+  const mode = config.hostKeyMode === 'verify' || config.hostKeyMode === 'off'
+    ? config.hostKeyMode
+    : 'accept-new'
+  const guard = {
+    mode,
+    lastError: null,
+    knownHosts: loadKnownHosts,
+    forgetHost() {
+      const kh = loadKnownHosts()
+      delete kh[id()]
+      try { mkdirSync(path.dirname(knownHostsFile()), { recursive: true }) } catch {}
+      writeFileSync(knownHostsFile(), JSON.stringify(kh, null, 2))
+    },
+    verifier(key) {
+      if (mode === 'off') return true
+      const fp = keyFingerprint(key)
+      const kh = loadKnownHosts()
+      const stored = kh[id()]
+      if (stored) {
+        if (stored.fingerprint === fp) return true
+        guard.lastError =
+          `host key for ${id()} CHANGED (stored ${stored.fingerprint}, received ${fp}) — ` +
+          'possible man-in-the-middle; run /remote-forget-key to re-trust if this is expected'
+        return false
+      }
+      if (mode === 'verify') {
+        guard.lastError = `unknown host key for ${id()} (hostKeyMode=verify) — trust it first with accept-new`
+        return false
+      }
+      kh[id()] = { algo: blobAlgorithm(key) || (key && key.algo) || 'unknown', fingerprint: fp, firstSeen: new Date().toISOString() }
+      try { mkdirSync(path.dirname(knownHostsFile()), { recursive: true }) } catch {}
+      writeFileSync(knownHostsFile(), JSON.stringify(kh, null, 2))
+      return true
+    },
+  }
+  return guard
+}
+
+/** Whether the current target's key has been recorded/trusted before. */
+function isHostKeyKnown(host, port) {
+  return Object.prototype.hasOwnProperty.call(loadKnownHosts(), `${host}:${port}`)
+}
+
 // ── SSH pool (key OR password) ──────────────────────────────────────────────
 
 class SshPool {
@@ -232,6 +452,9 @@ class SshPool {
     this.config = config
     this.client = null
     this.connecting = null
+    // Generational token: bumped on every target change / close so a stale
+    // in-flight connect can never hand this pool a connection to an old host.
+    this.epoch = 0
   }
 
   resolveKeyPath() {
@@ -257,31 +480,47 @@ class SshPool {
   connect() {
     if (this.client) return Promise.resolve(this.client)
     if (this.connecting) return this.connecting
-    this.connecting = this._doConnect().finally(() => {
-      this.connecting = null
-    })
-    return this.connecting
+    const epoch = this.epoch
+    const pending = this._doConnect(epoch)
+    this.connecting = pending
+    const clear = () => {
+      if (this.epoch === epoch && this.connecting === pending) this.connecting = null
+    }
+    // Keep the chain clean in both directions: the raw pending is what callers
+    // await (they still see rejections); this side just clears the slot.
+    pending.then(clear, clear)
+    return pending
   }
 
-  _doConnect() {
+  _doConnect(epoch) {
     return new Promise((resolve, reject) => {
       const client = new Client()
       let settled = false
+      // Fresh host-key guard per connect attempt so lastError is never stale.
+      const guard = createHostKeyGuard(this.config)
+      const isCurrent = () => this.epoch === epoch
       const fail = (err) => {
         if (settled) return
         settled = true
-        if (this.client === client) this.client = null
-        reject(err)
+        if (isCurrent() && this.client === client) this.client = null
+        reject(guard.lastError ? new Error(guard.lastError) : err)
       }
       client.on('ready', () => {
         if (settled) return
         settled = true
+        if (!isCurrent()) {
+          // The target changed while we were connecting — never adopt this
+          // client, and make sure the caller learns the connect is void.
+          try { client.end() } catch {}
+          reject(new Error('ssh target changed during connect'))
+          return
+        }
         this.client = client
         resolve(client)
       })
       client.on('error', fail)
       client.on('close', () => {
-        if (this.client === client) this.client = null
+        if (isCurrent() && this.client === client) this.client = null
         fail(new Error('ssh connection closed'))
       })
 
@@ -292,6 +531,7 @@ class SshPool {
         readyTimeout: this.config.connectTimeoutMs,
         keepaliveInterval: 15000,
         keepaliveCountMax: 3,
+        hostVerifier: (key) => guard.verifier(key),
       }
       if (this.config.password) {
         opts.password = this.config.password
@@ -341,9 +581,17 @@ class SshPool {
               if (settled) return
               exitCode = -1
               exitSignal = 'TIMEOUT'
+              // Kill the remote command (SIGTERM) rather than just dropping the
+              // channel, so a runaway process cannot keep running and holding
+              // the SSH connection after we've given up on its output. The hard
+              // close below frees the channel even if the process ignores it.
               try {
-                stream.close()
+                if (typeof stream.signal === 'function') stream.signal('SIGTERM')
               } catch {}
+              const hardClose = setTimeout(() => {
+                try { stream.close() } catch {}
+              }, 800)
+              if (typeof hardClose.unref === 'function') hardClose.unref()
               settle()
             }, timeoutMs || this.config.commandTimeoutMs)
             stream.on('close', (code, signal) => {
@@ -389,8 +637,17 @@ class SshPool {
   }
 
   close() {
+    // Bump the epoch so any in-flight connect is orphaned, drop the pending
+    // promise (its rejection becomes nobody's problem — swallow it), and end
+    // the live client if there is one.
+    this.epoch++
     const client = this.client
     this.client = null
+    const pending = this.connecting
+    this.connecting = null
+    if (pending && typeof pending.catch === 'function') {
+      try { pending.catch(() => {}) } catch {}
+    }
     if (client) {
       try {
         client.end()
@@ -404,6 +661,10 @@ class SshPool {
 export async function apply(ctx, config) {
   const pool = new SshPool(config)
   ctx.effect(() => () => pool.close(), 'dsh-remote.close')
+
+  // Bring any pre-0.6 data (~/.dsh/remote-workspaces) into the DSH_HOME-based
+  // location so existing machines + mirrors keep working after the move.
+  migrateLegacyData()
 
   // ── machine registry (multi-host) ─────────────────────────────────────────
   const store = loadMachines()
@@ -433,6 +694,19 @@ export async function apply(ctx, config) {
     if (cur && cur.host) applyMachine(config, cur)
   }
 
+  /** Set the active remote workspace AND persist it on the current machine so
+   * it survives restarts (previously a tool-set workspace reset on reload). */
+  const persistWorkspace = (p) => {
+    config.workspace = p
+    if (store.currentId) {
+      const i = machineIndex(store.currentId)
+      if (i >= 0) {
+        machines[i].workspace = p
+        saveMachines(machines, store.currentId)
+      }
+    }
+  }
+
   const run = async (cmd, opts = {}) => {
     const res = await pool.exec(cmd, opts.timeoutMs)
     const parts = []
@@ -445,27 +719,51 @@ export async function apply(ctx, config) {
     return text
   }
 
-  /** Structured-listing of a remote dir: name + usable type. `dir` is decided by
-   * `[ -d ]`, which FOLLOWS symlinks — so a symlink to a directory is enterable
-   * (the picker can drill into it), while a file symlink stays a file. */
+  /** Structured-listing of a remote dir: name + usable type.
+   *
+   * Implementation note — this deliberately uses `ls -1A -F` instead of a
+   * `for f in .[!.]* *` loop or `find`:
+   *   • `-F` marks real directories with a trailing `/` and symlinks with `@`;
+   *     on Linux GNU ls classifies from readdir `d_type` WITHOUT stat, so the
+   *     listing can never hang on a stuck FUSE/network mount the way
+   *     `[ -d "$f" ]` / `find -type` do (those stat every entry and block in
+   *     an uninterruptible D-state that even SIGTERM can't clear).
+   *   • there is no shell glob, so zsh's `nomatch` can't abort the listing on
+   *     directories that have no dotfiles (the old `.[!.]*` glob did).
+   * Symlinked entries (e.g. `/bin@`) get ONE bounded follow-up stat — only
+   * symlinks are touched, never the stuck mount — to decide dir vs file. */
   const listDirStructured = async (p, timeoutMs) => {
     const target = p || '/'
-    const cmd =
-      `cd ${shq(target)} 2>/dev/null && for f in .[!.]* *; do ` +
-      `[ -e "$f" ] || [ -L "$f" ] || continue; ` +
-      `if [ -d "$f" ]; then printf 'd\\t%s\\n' "$f"; else printf 'f\\t%s\\n' "$f"; fi; done`
-    const res = await pool.exec(cmd, timeoutMs || config.commandTimeoutMs)
-    const items = []
+    const to = timeoutMs || config.commandTimeoutMs
+    const res = await pool.exec(`ls -1A -F ${shq(target)}`, to)
     if (res.code !== 0 && res.stderr) {
       throw new Error('ls failed: ' + (res.stderr || '').trim())
     }
+    const items = []
+    const symIdx = []
     for (const line of String(res.stdout || '').split('\n')) {
-      const idx = line.indexOf('\t')
-      if (idx < 0) continue
-      const type = line.slice(0, idx)
-      const name = line.slice(idx + 1)
-      if (name === '.' || name === '..' || !name) continue
-      items.push({ type: type === 'd' ? 'dir' : 'file', name })
+      if (!line) continue
+      const c = line[line.length - 1]
+      if (c === '/') items.push({ type: 'dir', name: line.slice(0, -1) })
+      else if (c === '@') {
+        items.push({ type: 'symlink', name: line.slice(0, -1) })
+        symIdx.push(items.length - 1)
+      } else {
+        // regular file, executable (`*`), socket (`=`), fifo (`|`) …
+        items.push({ type: 'file', name: c === '*' || c === '=' || c === '|' ? line.slice(0, -1) : line })
+      }
+    }
+    // Resolve symlink-to-dir vs symlink-to-file. Bounded and failure-tolerant:
+    // if the stat is slow it times out and symlinks just degrade to files
+    // (non-enterable) instead of failing the whole browse.
+    if (symIdx.length) {
+      const cmd = 'for f in ' + symIdx.map((i) => shq(items[i].name)).join(' ') +
+        '; do if [ -d "$f" ]; then echo d; else echo f; fi; done'
+      const r2 = await pool.exec(cmd, Math.min(to, 5000))
+      const kinds = String(r2.stdout || '').split('\n')
+      for (let i = 0; i < symIdx.length; i++) {
+        items[symIdx[i]].type = (kinds[i] || '').trim() === 'd' ? 'dir' : 'file'
+      }
     }
     return { path: target, items }
   }
@@ -482,6 +780,8 @@ export async function apply(ctx, config) {
     localMirror: wsPath() ? mirrorDirFor(wsPath(), config.host, config.username, config.port) : '',
     currentId: store.currentId || null,
     machines: machines.map(sanitizeMachine),
+    hostKeyMode: config.hostKeyMode === 'verify' || config.hostKeyMode === 'off' ? config.hostKeyMode : 'accept-new',
+    hostKeyKnown: config.host ? isHostKeyKnown(config.host, config.port) : false,
   })
 
   // ── tools ─────────────────────────────────────────────────────────────────
@@ -495,7 +795,7 @@ export async function apply(ctx, config) {
     defineTool({
       name: 'rw_info',
       description:
-        'Show the remote environment: host/user/port, connection health, and the current remote workspace path. Call this first to orient, or when a remote_* call fails to check connectivity.',
+        'Show the remote environment: host/user/port, connection health, and the current remote workspace path. Call this first to orient, or when an rw_* call fails to check connectivity.',
       parameters: {},
       output: {
         schema: { type: 'object', additionalProperties: false, properties: { text: { type: 'string', required: true } } },
@@ -506,6 +806,7 @@ export async function apply(ctx, config) {
         const lines = [
           `Remote host: ${s.username || '<user>'}@${s.host || '<host>'}:${s.port}`,
           `Current remote workspace: ${s.workspace || '(none — call rw_pick_workspace to set one)'}`,
+          `Local mirror: ${s.localMirror || '(none)'}`,
           `Connected: ${s.connected ? 'yes' : 'no'}`,
           '',
         ]
@@ -577,10 +878,10 @@ export async function apply(ctx, config) {
         const res = await pool.exec(`if [ -d ${shq(p)} ]; then echo DIR; else echo NOTDIR; fi`)
         const ok = res.stdout.trim() === 'DIR'
         if (!ok) return { text: `not a directory (or missing) on ${p}` }
-        config.workspace = p
+        persistWorkspace(p)
         const local = ensureMirror(p, config.host, config.username, config.port)
         return {
-          text: `Remote workspace set to ${p} on ${config.username}@${config.host}.\nLocal mirror (native workspace path): ${local}\n\nRun rw_sync to download its files into the local mirror.`,
+          text: `Remote workspace set to ${p} on ${config.username}@${config.host} (saved for this machine).\nLocal mirror (native workspace path): ${local}\n\nRun rw_sync to download its files into the local mirror.`,
         }
       },
     }),
@@ -610,8 +911,11 @@ export async function apply(ctx, config) {
         } catch (err) {
           return { text: 'sftp unavailable: ' + ((err && err.message) || err) }
         }
-        const { files, touched } = await syncTree(sftp, p, local, depth, maxFiles)
-        return { text: `Downloaded ${files} file(s) from ${p} → ${local}${files >= maxFiles ? ' (hit download cap)' : ''}.` }
+        const r = await syncTree(sftp, p, local, depth, maxFiles, config.maxFileBytes)
+        let text = `Downloaded ${r.files} file(s) from ${p} → ${local}${r.files >= maxFiles ? ' (hit download cap)' : ''}.`
+        if (r.skippedUnchanged) text += ` ${r.skippedUnchanged} unchanged.`
+        if (r.skippedLarge) text += ` ${r.skippedLarge} too large (over ${config.maxFileBytes} bytes).`
+        return { text }
       },
     }),
 
@@ -638,8 +942,11 @@ export async function apply(ctx, config) {
         } catch (err) {
           return { text: 'sftp unavailable: ' + ((err && err.message) || err) }
         }
-        const { files } = await pushTree(sftp, local, p, p, maxFiles)
-        return { text: `Uploaded ${files} file(s) from ${local} → ${p}.` }
+        const { files, skippedUnchanged, skippedLarge, pushed } = await pushTree(sftp, local, p, maxFiles, config.maxFileBytes)
+        let text = `Uploaded ${files} file(s) from ${local} → ${p}.`
+        if (skippedUnchanged) text += ` ${skippedUnchanged} unchanged.`
+        if (skippedLarge) text += ` ${skippedLarge} too large (over ${config.maxFileBytes} bytes).`
+        return { text }
       },
     }),
 
@@ -657,7 +964,9 @@ export async function apply(ctx, config) {
       async execute(args) {
         const p = args.path ? normalizeRemotePath(String(args.path)) : wsPath()
         if (!p) throw new Error('rw_list_dir: no path and no remote workspace set')
-        return { text: await run(`ls -la --color=never ${shq(p)}`) }
+        // `ls -la` (no --color / -N): piped output never carries color on either
+        // GNU or BSD ls, so the GNU-only flags would break macOS/BSD remotes.
+        return { text: await run(`ls -la ${shq(p)}`) }
       },
     }),
 
@@ -682,7 +991,9 @@ export async function apply(ctx, config) {
         let from = Math.max(Number(args.startLine) || 1, 1)
         let to = Number(args.endLine) || 0
         if (!to || to - from + 1 > maxLines) to = from + maxLines - 1
-        const raw = await run(`sed -n '${from},${to}p' -- ${shq(p)}`, { timeoutMs: config.commandTimeoutMs })
+        // Absolute paths start with '/', so the GNU-only `--` terminator is
+        // dropped to keep BSD/macOS sed (which rejects `--`) working.
+        const raw = await run(`sed -n '${from},${to}p' ${shq(p)}`, { timeoutMs: config.commandTimeoutMs })
         const numbered = raw.split('\n').map((l, i) => `${String(from + i).padStart(6)}\t${l}`).join('\n').replace(/\s+$/, '')
         let text = numbered === '' ? '(empty or out of range)' : numbered
         if (!args.endLine) text += '\n(shown up to ' + maxLines + ' lines; use startLine/endLine to page)'
@@ -693,9 +1004,10 @@ export async function apply(ctx, config) {
     defineTool({
       name: 'rw_exec',
       description:
-        'Run a shell command on the remote host. Use for anything that is not reading a file (build, test, grep, etc). Output is capped.',
+        'Run a shell command on the remote host. Use for anything that is not reading a file (build, test, grep, etc). Output is capped. Runs in the current remote workspace by default; pass cwd to run elsewhere.',
       parameters: {
         command: { type: 'string', required: true, description: 'Shell command (run on the remote host)' },
+        cwd: { type: 'string', description: 'Working directory for the command (default: the current remote workspace)' },
       },
       output: {
         schema: { type: 'object', additionalProperties: false, properties: { text: { type: 'string', required: true } } },
@@ -704,7 +1016,10 @@ export async function apply(ctx, config) {
       async execute(args) {
         const cmd = String(args.command || '')
         if (!cmd) throw new Error('rw_exec: command is required')
-        return { text: await run(cmd, { timeoutMs: config.commandTimeoutMs }) }
+        const ws = wsPath()
+        const cwd = args.cwd ? normalizeRemotePath(String(args.cwd)) : (ws || '')
+        const full = cwd ? `cd ${shq(cwd)} && ${cmd}` : cmd
+        return { text: await run(full, { timeoutMs: config.commandTimeoutMs }) }
       },
     }),
 
@@ -751,6 +1066,110 @@ export async function apply(ctx, config) {
     }),
 
     defineTool({
+      name: 'rw_search',
+      description:
+        'Search remote files for a pattern (grep, recursive, case-insensitive by default). Returns matching file:line rows; output is capped. Use instead of rw_exec grep when you want a bounded, portable search.',
+      parameters: {
+        pattern: { type: 'string', required: true, description: 'Pattern to search for (extended regex)' },
+        path: { type: 'string', description: 'Directory to search (default: current remote workspace)' },
+        glob: { type: 'string', description: 'Only files whose name matches this glob, e.g. *.ts (optional)' },
+        ignoreCase: { type: 'boolean', description: 'Case-insensitive search (default true)' },
+      },
+      output: {
+        schema: { type: 'object', additionalProperties: false, properties: { text: { type: 'string', required: true } } },
+        render: (_a, a) => [{ type: 'text', text: a.text }],
+      },
+      async execute(args) {
+        const pattern = String(args.pattern || '')
+        if (!pattern) throw new Error('rw_search: pattern is required')
+        const ws = wsPath()
+        const dir = args.path ? normalizeRemotePath(String(args.path)) : (ws || '')
+        if (!dir) throw new Error('rw_search: no path and no remote workspace set')
+        const flags = 'r' + (args.ignoreCase === false ? '' : 'i') + 'nE'
+        const name = args.glob ? ` -name ${shq(String(args.glob))}` : ''
+        // find … -exec grep {} + is POSIX (BSD + GNU): `grep -RInE` alone would
+        // differ on BSD, and GNU-only --include is avoided in favor of find -name.
+        const cmd = `find ${shq(dir)} -type f${name} -exec grep -${flags} -H -- ${shq(pattern)} {} + 2>/dev/null | head -n 2000`
+        return { text: await run(cmd, { timeoutMs: Math.max(config.commandTimeoutMs, 30000) }) }
+      },
+    }),
+
+    defineTool({
+      name: 'rw_download',
+      description:
+        'Download a single remote file over SFTP into the local mirror of the current workspace (or to an explicit local path). Use when you need the actual file content locally, not just its text.',
+      parameters: {
+        path: { type: 'string', required: true, description: 'Absolute remote file path' },
+        localPath: { type: 'string', description: 'Local destination (default: the workspace mirror, preserving the relative path)' },
+      },
+      output: {
+        schema: { type: 'object', additionalProperties: false, properties: { ok: { type: 'boolean', required: true }, bytes: { type: 'integer' }, text: { type: 'string' } } },
+        render: (_a, a) => [{ type: 'text', text: a.text || (a.ok ? 'downloaded' : 'failed') }],
+      },
+      async execute(args) {
+        const p = normalizeRemotePath(String(args.path || ''))
+        if (!p || p === '/') throw new Error('rw_download: a remote file path is required')
+        let sftp
+        try {
+          sftp = await pool.sftp()
+        } catch (err) {
+          throw new Error('rw_download: sftp unavailable: ' + ((err && err.message) || err))
+        }
+        let local
+        if (args.localPath) {
+          local = path.resolve(String(args.localPath))
+        } else {
+          const ws = wsPath()
+          if (!ws) throw new Error('rw_download: no remote workspace set — pass localPath explicitly')
+          const base = mirrorDirFor(ws, config.host, config.username, config.port)
+          const rel = p.startsWith(ws) ? p.slice(ws.length).replace(/^\/+/, '') : p.slice(1)
+          local = path.join(base, rel)
+        }
+        mkdirSync(path.dirname(local), { recursive: true })
+        const buf = await sftp.readFile(p)
+        writeFileSync(local, buf)
+        const bytes = buf.byteLength
+        return { ok: true, bytes, text: `downloaded ${bytes} bytes from ${p} → ${local}` }
+      },
+    }),
+
+    defineTool({
+      name: 'rw_upload',
+      description:
+        'Upload a local file over SFTP to a path on the remote host (creating parent directories if needed). Use to push a local file directly, without a full rw_push of the whole mirror.',
+      parameters: {
+        localPath: { type: 'string', required: true, description: 'Absolute local file path' },
+        path: { type: 'string', required: true, description: 'Absolute remote destination path' },
+      },
+      output: {
+        schema: { type: 'object', additionalProperties: false, properties: { ok: { type: 'boolean', required: true }, bytes: { type: 'integer' }, text: { type: 'string' } } },
+        render: (_a, a) => [{ type: 'text', text: a.text || (a.ok ? 'uploaded' : 'failed') }],
+      },
+      async execute(args) {
+        const rp = normalizeRemotePath(String(args.path || ''))
+        const lp = String(args.localPath || '')
+        if (!rp || rp === '/' || !lp) throw new Error('rw_upload: both localPath and a remote path are required')
+        if (!existsSync(lp)) throw new Error(`rw_upload: local file not found: ${lp}`)
+        let sftp
+        try {
+          sftp = await pool.sftp()
+        } catch (err) {
+          throw new Error('rw_upload: sftp unavailable: ' + ((err && err.message) || err))
+        }
+        const segs = remoteDirname(rp).split('/').filter(Boolean)
+        let cur = ''
+        for (const s of segs) {
+          cur += '/' + s
+          try { await sftp.mkdir(cur) } catch { /* exists or no perms */ }
+        }
+        const buf = readFileSync(lp)
+        await sftp.writeFile(rp, buf)
+        const bytes = buf.byteLength
+        return { ok: true, bytes, text: `uploaded ${bytes} bytes from ${lp} → ${rp}` }
+      },
+    }),
+
+    defineTool({
       name: 'rw_disconnect',
       description:
         'Close the current SSH connection to the remote host, releasing the persistent pool. Useful to rotate connections or after a long idle.',
@@ -780,7 +1199,7 @@ export async function apply(ctx, config) {
       return (
         '## Remote workspace\n' +
         `Current remote workspace: ${config.username}@${config.host}:${w}\n` +
-        'Use the remote_* tools (rw_list_dir / rw_read_file / rw_exec) to inspect and act on files on the remote host. Treat this directory as the working root for this task.'
+        'Use the rw_* tools (rw_list_dir / rw_read_file / rw_write_file / rw_exec / rw_search) to inspect and act on files on the remote host. Treat this directory as the working root for this task.'
       )
     },
   })
@@ -798,9 +1217,19 @@ export async function apply(ctx, config) {
           text:
             `Remote host: ${s.username}@${s.host || '<none>'} (connected: ${s.connected})\n` +
             `Remote workspace: ${s.workspace || '(none)'}\n` +
-            `\nUse tools: rw_list_dir / rw_read_file / rw_exec.` +
+            `Host key: ${s.hostKeyKnown ? 'trusted ✓' : 'not yet trusted'} (mode=${s.hostKeyMode})\n` +
+            (s.hostKeyKnown ? `  — if the key changed / was mistrusted, run /remote-forget-key\n` : '') +
+            `\nUse tools: rw_list_dir / rw_read_file / rw_exec / rw_search.` +
             (s.workspace ? `\nCurrently working in ${s.workspace}.` : ''),
         }
+      },
+    })
+    commands.register({
+      name: 'remote-forget-key',
+      description: 'Drop the trusted host-key record for the current machine so the next connect re-records it.',
+      handler: () => {
+        createHostKeyGuard(config).forgetHost()
+        return { kind: 'success', text: `forgot host key for ${config.host || '<none>'}:${config.port} — the next connect will re-record it.` }
       },
     })
   }
@@ -814,12 +1243,62 @@ export async function apply(ctx, config) {
     res.setHeader('Content-Type', 'application/json; charset=utf-8')
     res.end(JSON.stringify(body))
   }
+  // Cap request bodies (1 MiB) so a malformed client cannot force us to buffer
+  // unbounded memory on a local-only route.
+  const MAX_BODY_BYTES = 1024 * 1024
   const readBody = (req) =>
     new Promise((resolve) => {
       const chunks = []
-      req.on('data', (c) => chunks.push(c))
+      let total = 0
+      req.on('data', (c) => {
+        total += c.length
+        if (total > MAX_BODY_BYTES) {
+          req.removeAllListeners('data')
+          resolve('{}')
+          return
+        }
+        chunks.push(c)
+      })
       req.on('end', () => resolve(chunks.join('')))
     })
+
+  // ── 本机目录选择器：DSH directoryPicker 服务优先，缺位/非原生则自持兜底 ──
+  // 背景：web-app 的 `directory-picker` 行（-auto）在桌面启动路径里不物化成
+  // loader 条目，`ctx.get('directoryPicker')` 实测为 null（沙箱 + 产品同路径）。
+  // 因此插件自带原生选择器：macOS osascript / Linux zenity→kdialog，与 DSH
+  // native 后端同一套调用约定（取消 → { cancelled }，成功 → { path }）。
+  const PICK_TIMEOUT_MS = 120000
+  const runPick = (bin, args) =>
+    new Promise((resolve, reject) => {
+      execFile(bin, args, { timeout: PICK_TIMEOUT_MS, maxBuffer: 1 << 20 }, (err, stdout, stderr) => {
+        if (err) {
+          const code = err.code
+          const msg = String(stderr || '')
+          // 用户在对话框里点了取消：osascript 退出码 1 + "User canceled"/-128
+          if (code === 1 && /(?:user canceled|-128)/i.test(msg)) return resolve({ cancelled: true })
+          if (err.signal || err.killed) return reject(new Error('目录选择已超时，请重试或直接在输入框填本地路径'))
+          if (code === 'ENOENT') return reject(Object.assign(new Error('未找到目录选择器程序 ' + bin), { code }))
+          return reject(new Error((msg.trim() || (err && err.message) || '无法打开系统文件夹选择器').split('\n')[0]))
+        }
+        const p = String(stdout || '').replace(/[\r\n]+$/, '').trim()
+        resolve(p ? { path: p } : { cancelled: true })
+      })
+    })
+  const pickLocalNative = async () => {
+    const platform = process.platform
+    if (platform === 'darwin') {
+      return runPick('osascript', ['-e', 'set selectedFolder to choose folder with prompt "Select Workspace Directory"', '-e', 'POSIX path of selectedFolder'])
+    }
+    if (platform === 'linux') {
+      try {
+        return await runPick('zenity', ['--file-selection', '--directory', '--title=Select Workspace Directory'])
+      } catch (err) {
+        if (err && err.code === 'ENOENT') return runPick('kdialog', ['--getexistingdirectory', '.', '--title', 'Select Workspace Directory'])
+        throw err
+      }
+    }
+    throw new Error('当前系统不支持自动打开目录选择器，请在输入框直接填本地路径')
+  }
 
   const routes = [
     {
@@ -857,8 +1336,10 @@ export async function apply(ctx, config) {
       path: '/dsh-remote/ls',
       handler: async (req, res) => {
         try {
-          const m = (req.url || '').match(/path=([^&]*)/)
-          const p = m ? decodeURIComponent(m[1]) : wsPath()
+          // Proper URL parsing so `+` in a path decodes to a literal space
+          // (the old regex missed it).
+          const q = new URL(req.url, 'http://localhost').searchParams
+          const p = q.get('path') ? decodeURIComponent(q.get('path')) : wsPath()
           const out = await listDirStructured(p || '/')
           return sendJson(res, 200, { path: p, items: out.items })
         } catch (err) {
@@ -877,7 +1358,7 @@ export async function apply(ctx, config) {
           if (!p || p === '/') return sendJson(res, 400, { error: 'path must be an absolute directory' })
           const r = await pool.exec(`if [ -d ${shq(p)} ]; then echo DIR; else echo NOTDIR; fi`)
           if (r.stdout.trim() !== 'DIR') return sendJson(res, 400, { ok: false, error: `not a directory: ${p}` })
-          config.workspace = p
+          persistWorkspace(p)
           const local = ensureMirror(p, config.host, config.username, config.port)
           return sendJson(res, 200, { ok: true, workspace: p, localMirror: local, ...status() })
         } catch (err) {
@@ -895,13 +1376,12 @@ export async function apply(ctx, config) {
           const p = normalizeRemotePath(String(payload.path || ''))
           if (!p || p === '/') return sendJson(res, 400, { ok: false, error: 'path must be an absolute directory' })
           if (!config.host) return sendJson(res, 400, { ok: false, error: 'no remote host configured/connected — connect first' })
-          // optional: verify it's a directory over SSH when connected
-          if (pool.client) {
-            const r = await pool.exec(`if [ -d ${shq(p)} ]; then echo DIR; else echo NOTDIR; fi`)
-            if (r.stdout.trim() !== 'DIR') return sendJson(res, 400, { ok: false, error: `not a directory (or unreachable): ${p}` })
-          }
+          // Always verify over SSH (connecting if needed) so an unconnected or
+          // wrong host can never silently mint a mirror for a bogus path.
+          const r = await pool.exec(`if [ -d ${shq(p)} ]; then echo DIR; else echo NOTDIR; fi`)
+          if (r.stdout.trim() !== 'DIR') return sendJson(res, 400, { ok: false, error: `not a directory (or unreachable): ${p}` })
           const local = ensureMirror(p, config.host, config.username, config.port)
-          config.workspace = p
+          persistWorkspace(p)
           return sendJson(res, 200, { ok: true, path: p, localMirror: local, ...status() })
         } catch (err) {
           return sendJson(res, 500, { ok: false, error: String((err && err.message) || err) })
@@ -914,16 +1394,38 @@ export async function apply(ctx, config) {
       handler: async (req, res) => {
         if (req.method !== 'POST') return sendJson(res, 405, { ok: false, error: 'method not allowed' })
         try {
-          const dp = (ctx && ctx.get && ctx.get('directoryPicker')) || (ctx && ctx.directoryPicker) || null
-          if (!dp || typeof dp.capability !== 'function') return sendJson(res, 400, { ok: false, error: '本地目录选择器服务不可用（缺少 DSH directory-picker backend）' })
-          const cap = await Promise.resolve(dp.capability())
-          if (!cap || cap.kind !== 'native' || typeof cap.pick !== 'function') return sendJson(res, 400, { ok: false, error: '本地目录选择器不可用（当前为非原生/浏览后端，请在输入框手动填本地路径）' })
-          const pickAbort = new AbortController()
-          const signal = pickAbort.signal || null
-          const picked = await Promise.resolve(cap.pick(signal))
-          pickAbort.abort()
-          if (!picked || typeof picked !== 'string') return sendJson(res, 200, { ok: true, cancelled: true })
-          return sendJson(res, 200, { ok: true, path: picked })
+          // 1) 优先用 DSH directoryPicker 服务（native 后端）。必须用
+          //    ctx.get() 按名取：属性形式 ctx.directoryPicker 会抛 cordis
+          //    "cannot get property ... without inject"（该名字未在本插件
+          //    inject 里声明），ctx.get() 无此要求、缺失返回 null。
+          // 2) 服务缺位或非 native（实测 web-app 的 -auto 行在桌面启动路径
+          //    不物化后端）→ 自持 osascript/zenity/kdialog 兜底。
+          let outcome = null
+          let via = 'service'
+          const dp = (ctx && typeof ctx.get === 'function') ? (ctx.get('directoryPicker') || null) : null
+          if (dp && typeof dp.capability === 'function') {
+            try {
+              const cap = await Promise.resolve(dp.capability())
+              if (cap && cap.kind === 'native' && typeof cap.pick === 'function') {
+                const pickAbort = new AbortController()
+                const p = await Promise.resolve(cap.pick(pickAbort.signal || null))
+                pickAbort.abort()
+                outcome = (typeof p === 'string' && p) ? { path: p } : { cancelled: true }
+              }
+            } catch (err) {
+              outcome = null // DSH 服务出错 → 落到自持兜底
+            }
+          }
+          if (!outcome) {
+            via = 'own'
+            try {
+              outcome = await pickLocalNative()
+            } catch (err) {
+              return sendJson(res, 500, { ok: false, error: String((err && err.message) || err) + ' — 可直接在输入框填本地路径' })
+            }
+          }
+          if (outcome.cancelled) return sendJson(res, 200, { ok: true, cancelled: true, via })
+          return sendJson(res, 200, { ok: true, path: outcome.path, via })
         } catch (err) {
           return sendJson(res, 500, { ok: false, error: String((err && err.message) || err) })
         }
@@ -1018,6 +1520,18 @@ export async function apply(ctx, config) {
         } catch (err) {
           return sendJson(res, 500, { ok: false, error: String((err && err.message) || err) })
         }
+      },
+    },
+    {
+      kind: 'exact',
+      path: '/dsh-remote/forget-key',
+      handler: async (req, res) => {
+        if (req.method !== 'POST') return sendJson(res, 405, { ok: false, error: 'method not allowed' })
+        // Drop the trusted host-key record for the CURRENT target so the next
+        // connect re-records it (use after an intentional host reinstall or a
+        // false MITM alarm).
+        createHostKeyGuard(config).forgetHost()
+        return sendJson(res, 200, { ok: true, ...status() })
       },
     },
   ]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-remote",
-  "version": "0.5.10",
+  "version": "0.6.7",
   "description": "Remote-work assistant for DeepSeek Harness: connect SSH (password or key), pick a remote workspace, operate on it with rw_pick_workspace / rw_list_dir / rw_read_file / rw_exec / rw_sync tools, and mirror it to a real local directory (SFTP) so the DSH native workspace can adopt it.",
   "license": "MIT",
   "author": "flymysql <flyphp@outlook.com>",

--- a/scripts/boot-smoke.sh
+++ b/scripts/boot-smoke.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# 启动冒烟测试（Boot smoke test）—— dsh-remote 部署后必跑
+#
+# 背景：v0.6.1 曾因命令名 `remote.forget-key` 违反 dsh-commands 约束
+# （/^[a-z][a-z0-9_-]*$/u）导致插件树加载失败、整个 DSH Desktop 无法启动。
+# 从那以后，任何"宿主半"改动部署后都必须跑本脚本验证插件树能加载。
+#
+# 做法：在隔离的临时 DSH_HOME 里硬链接拷贝 web profile（快、不占额外空间），
+# 用桌面自带 harness 起一个临时端口的实例，等它打出 "dsh web:"（健康）或
+# "DSH entry failed"（失败），然后杀掉并清理。
+#
+# 用法：
+#   scripts/boot-smoke.sh            # 测桌面版 web profile（默认）
+#   PROFILE=xxx scripts/boot-smoke.sh
+set -euo pipefail
+
+APP="/Users/4FMTWRV/Downloads/dsh-desktop/dist/mac-arm64/DSH Desktop.app/Contents/Resources"
+SRC_HOME="${DSH_HOME:-$HOME/Library/Application Support/dsh-desktop/harness}"
+PROFILE="${PROFILE:-web}"
+PORT="${SMOKE_PORT:-53199}"
+
+if [ ! -f "$APP/app/node_modules/@deepseek-ai/dsh/lib/bin.js" ]; then
+  echo "❌ 未找到桌面版 harness 入口: $APP/app/node_modules/@deepseek-ai/dsh/lib/bin.js" >&2
+  exit 1
+fi
+
+TMP="$(mktemp -d)"
+cleanup() { rm -rf "$TMP"; }
+trap cleanup EXIT
+
+echo "⏱  准备隔离 profile（硬链接拷贝，免复制大体积 node_modules）…"
+mkdir -p "$TMP/harness/profiles"
+if ! cp -al "$SRC_HOME/profiles/$PROFILE" "$TMP/harness/profiles/$PROFILE" 2>/dev/null; then
+  cp -a "$SRC_HOME/profiles/$PROFILE" "$TMP/harness/profiles/$PROFILE"
+fi
+
+LOG="$TMP/boot.log"
+echo "⏱  启动隔离 harness（port $PORT）…"
+DSH_HOME="$TMP/harness" "$APP/app/node_modules/node/bin/node" --expose-internals \
+  "$APP/app/node_modules/@deepseek-ai/dsh/lib/bin.js" web \
+  --patch "$APP/dsh-desktop.patch.yml" --host 127.0.0.1 --port "$PORT" \
+  >"$LOG" 2>&1 &
+PID=$!
+
+ok=0
+for _ in $(seq 1 40); do
+  if grep -q "DSH entry failed" "$LOG"; then break; fi
+  if grep -q "dsh web: http" "$LOG"; then ok=1; break; fi
+  if ! kill -0 "$PID" 2>/dev/null; then break; fi
+  sleep 1
+done
+
+if [ "$ok" = 1 ]; then
+  echo "✅ 启动冒烟通过：插件树加载成功，harness 已在 :$PORT 起服务"
+  kill "$PID" 2>/dev/null || true
+  sleep 1
+  kill -9 "$PID" 2>/dev/null || true
+  exit 0
+fi
+
+echo "❌ 启动冒烟失败（插件树加载出错）："
+tail -25 "$LOG" || true
+exit 1

--- a/scripts/dev-run.sh
+++ b/scripts/dev-run.sh
@@ -1,0 +1,194 @@
+#!/usr/bin/env bash
+# dsh-remote —— 开发/沙箱模式（默认迭代方式）
+#
+# 为什么需要沙箱：产品 profile（DSH Desktop）里的 dsh-remote 声明为
+# `^0.5.10`，任何 npm / dsh plugin 重装都会把手工部署的文件覆盖回发行版
+# （v0.6.4 曾被重装回 0.5.10 顶掉的实证）。所以日常开发**禁止直接改产品
+# profile**，一律在本沙箱里迭代：
+#
+#   · 隔离 DSH_HOME（dev-harness/harness）—— 数据、profile、session 全独立，
+#     绝不碰产品 DSH_HOME。
+#   · profile 用硬链接拷贝产品 profile（快、省空间），再把已装的
+#     node_modules/dsh-remote/lib 覆盖为**源码 lib/ 的拷贝**——每次启动都会
+#     重新覆盖，改源码 → 重启沙箱即生效。
+#     （为什么不用 symlink：Node ESM 依赖按 realpath 解析，symlink 会把
+#     @deepseek-ai/schemastery 等解析到仓库根目录去，直接加载失败。
+#     拷贝才能让依赖沿 profiles/web/node_modules 解析，与产品环境一致。）
+#   · 从产品拷入 machines.json / known_hosts.json（首次）—— 沙箱里能看到
+#     你的真实机器，但增删改只写沙箱副本。
+#   · 用桌面自带 harness 起一个独立端口实例（默认 50599），浏览器打开即用。
+#
+# 用法：
+#   scripts/dev-run.sh                 # 启动沙箱（profile 缺失时自动创建，并覆盖最新 lib/）
+#   scripts/dev-run.sh --restart       # 重启（宿主半改动后用这个；会自动覆盖最新 lib/）
+#   scripts/dev-run.sh --refresh       # 重建 profile（重新从产品拷）+ 启动
+#   scripts/dev-run.sh --port 50888    # 自定义端口
+#   scripts/dev-run.sh --stop          # 停止沙箱实例
+#   scripts/dev-run.sh --status        # 查看运行状态
+#
+# 生效方式：宿主半（index.js）改动 → --restart；浏览器半（client.js）改动 →
+# --restart 后刷新页面（页面刷新本身只对 client 半；host 半必须重启沙箱）。
+set -euo pipefail
+
+APP="/Users/4FMTWRV/Downloads/dsh-desktop/dist/mac-arm64/DSH Desktop.app/Contents/Resources"
+PROD_HOME="${DSH_HOME:-$HOME/Library/Application Support/dsh-desktop/harness}"
+WORKSPACE="$(cd "$(dirname "$0")/.." && pwd)"
+SRC="$WORKSPACE"
+DEV_ROOT="$WORKSPACE/dev-harness"
+DEV_HOME="${DEV_HOME:-$DEV_ROOT/harness}"
+PORT="${DEV_PORT:-50599}"
+PROFILE="${PROFILE:-web}"
+LOG="$DEV_ROOT/dev.log"
+PIDFILE="$DEV_ROOT/dev.pid"
+
+ACTION=start
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --refresh) ACTION=refresh ;;
+    --restart) ACTION=restart ;;
+    --stop)    ACTION=stop ;;
+    --status)  ACTION=status ;;
+    --port)    PORT="$2"; shift 2; continue ;;
+    *)         echo "⚠️  忽略未知参数: $1" ;;
+  esac
+  shift
+done
+
+NODE="$APP/app/node_modules/node/bin/node"
+BIN="$APP/app/node_modules/@deepseek-ai/dsh/lib/bin.js"
+PATCH="$APP/dsh-desktop.patch.yml"
+PROFILE_DIR="$DEV_HOME/profiles/$PROFILE"
+INSTALL_DIR="$PROFILE_DIR/node_modules/dsh-remote"
+
+require_app() {
+  if [ ! -f "$BIN" ]; then
+    echo "❌ 未找到桌面版 harness 入口: $BIN" >&2
+    echo "   若 DSH Desktop 路径变化，请修改本脚本顶部 APP 常量。" >&2
+    exit 1
+  fi
+  if [ ! -f "$PATCH" ]; then
+    echo "❌ 未找到桌面补丁: $PATCH" >&2
+    exit 1
+  fi
+}
+
+is_running() {
+  [ -f "$PIDFILE" ] || return 1
+  local pid; pid="$(cat "$PIDFILE" 2>/dev/null || echo '')"
+  [ -n "$pid" ] && kill -0 "$pid" 2>/dev/null
+}
+
+do_stop() {
+  if is_running; then
+    local pid; pid="$(cat "$PIDFILE")"
+    echo "⏹  停止沙箱实例 (pid $pid, port $PORT) …"
+    kill "$pid" 2>/dev/null || true
+    for _ in $(seq 1 10); do kill -0 "$pid" 2>/dev/null || break; sleep 1; done
+    kill -9 "$pid" 2>/dev/null || true
+    rm -f "$PIDFILE"
+    echo "✅ 已停止。"
+  else
+    rm -f "$PIDFILE"
+    echo "ℹ️  沙箱未在运行。"
+  fi
+}
+
+# 覆盖已装 dsh-remote/lib 为源码最新拷贝（连同清单/补丁）
+# 注意：写入前先 unlink（rm -f），绝不允许通过硬链接就地覆写产品文件
+# （cp -al 之后写入会顺着硬链接改到产品——v0.6.5 开发时真踩过）。
+sync_lib() {
+  mkdir -p "$INSTALL_DIR"
+  rm -rf "$INSTALL_DIR/lib"
+  rm -f "$INSTALL_DIR/package.json" "$INSTALL_DIR/cordis.patch.yml" "$INSTALL_DIR/LICENSE"
+  cp -r "$SRC/lib" "$INSTALL_DIR/lib"
+  cp "$SRC/package.json" "$INSTALL_DIR/package.json"
+  cp "$SRC/cordis.patch.yml" "$INSTALL_DIR/cordis.patch.yml"
+  echo "   lib/ 已覆盖为源码最新（$(grep '"version"' "$SRC/package.json" | head -1 | tr -d ' ",' )）"
+}
+
+build_profile() {
+  echo "⏱  创建沙箱 profile（硬链接拷贝产品 profile）…"
+  mkdir -p "$DEV_HOME/profiles"
+  if [ ! -d "$PROD_HOME/profiles/$PROFILE" ]; then
+    echo "❌ 产品 profile 不存在: $PROD_HOME/profiles/$PROFILE" >&2
+    exit 1
+  fi
+  if [ -d "$PROFILE_DIR" ]; then rm -rf "$PROFILE_DIR"; fi
+  if ! cp -al "$PROD_HOME/profiles/$PROFILE" "$PROFILE_DIR" 2>/dev/null; then
+    cp -a "$PROD_HOME/profiles/$PROFILE" "$PROFILE_DIR"
+  fi
+  # 彻底解耦 dsh-remote：删掉硬链接目录，重建为独立目录再放源码拷贝，
+  # 这样后续 sync_lib 的所有写入都不会碰到产品文件。
+  rm -rf "$INSTALL_DIR"
+  mkdir -p "$INSTALL_DIR"
+  sync_lib
+  # 守卫：确认沙箱 manifest 与产品不再是同一 inode（防硬链接写入）
+  local prod_pkg="$PROD_HOME/profiles/$PROFILE/node_modules/dsh-remote/package.json"
+  if [ -f "$prod_pkg" ]; then
+    local a b
+    a="$(stat -f %i "$INSTALL_DIR/package.json")"
+    b="$(stat -f %i "$prod_pkg")"
+    if [ "$a" = "$b" ]; then
+      echo "❌ 守卫失败：沙箱与产品 dsh-remote/package.json 同 inode，中止。" >&2
+      exit 1
+    fi
+  fi
+  # 数据种子：machines / known_hosts 从产品拷入（只读源，沙箱独立写）
+  mkdir -p "$DEV_HOME/remote-workspaces"
+  for f in machines.json known_hosts.json; do
+    if [ ! -f "$DEV_HOME/remote-workspaces/$f" ] && [ -f "$PROD_HOME/remote-workspaces/$f" ]; then
+      cp "$PROD_HOME/remote-workspaces/$f" "$DEV_HOME/remote-workspaces/$f"
+      echo "   已种子数据 remote-workspaces/$f"
+    fi
+  done
+}
+
+do_start() {
+  require_app
+  if is_running; then
+    echo "✅ 沙箱已在运行: http://127.0.0.1:$PORT  (pid $(cat "$PIDFILE"))"
+    echo "   重启用: scripts/dev-run.sh --restart"
+    return 0
+  fi
+  if [ ! -d "$PROFILE_DIR" ]; then
+    build_profile
+  else
+    sync_lib
+  fi
+  echo "⏱  启动隔离 harness（port $PORT, DSH_HOME=$DEV_HOME）…"
+  mkdir -p "$DEV_ROOT"
+  DSH_HOME="$DEV_HOME" "$NODE" --expose-internals \
+    "$BIN" web --patch "$PATCH" --host 127.0.0.1 --port "$PORT" \
+    >"$LOG" 2>&1 &
+  echo "$!" > "$PIDFILE"
+  local ok=0
+  for _ in $(seq 1 40); do
+    if grep -q "DSH entry failed" "$LOG"; then break; fi
+    if grep -q "dsh web: http" "$LOG"; then ok=1; break; fi
+    if ! kill -0 "$(cat "$PIDFILE")" 2>/dev/null; then break; fi
+    sleep 1
+  done
+  if [ "$ok" != 1 ]; then
+    echo "❌ 沙箱启动失败（插件树加载出错）：" >&2
+    tail -30 "$LOG" >&2 || true
+    exit 1
+  fi
+  echo "✅ 沙箱就绪: http://127.0.0.1:$PORT"
+  echo "   · 日志: $LOG"
+  echo "   · 停止: scripts/dev-run.sh --stop"
+  # 探针：验证插件 JSON 路由真的注册上了（不是只看健康行）
+  sleep 1
+  local code
+  code="$(curl -s -o /dev/null -w '%{http_code}' "http://127.0.0.1:$PORT/dsh-remote/machines" 2>/dev/null || echo '000')"
+  echo "   · 插件路由 /dsh-remote/machines → HTTP $code（200/404 均为插件已加载，401 需在页面内访问）"
+}
+
+case "$ACTION" in
+  stop)    do_stop ;;
+  status)
+    if is_running; then echo "🟢 运行中: http://127.0.0.1:$PORT (pid $(cat "$PIDFILE"))"; else echo "⚪ 未运行"; fi
+    ;;
+  refresh) do_stop; build_profile; do_start ;;
+  restart) do_stop; do_start ;;
+  start)   do_start ;;
+esac

--- a/scripts/dev-standards.md
+++ b/scripts/dev-standards.md
@@ -1,0 +1,76 @@
+# dsh 插件开发规范（固化版）
+
+> 依据：2026-08-19 事故 —— v0.6.1 把 slash 命令命名为 `remote.forget-key`（带点号），
+> 违反 dsh-commands 框架硬校验，导致插件树加载失败、**整个 DSH Desktop 无法启动**，
+> 靠人工修复才恢复。以下规范必须遵守，防止"自己把自己搞崩"。
+
+## 0. 铁律：日常开发用沙箱模式，禁止直接改产品 profile
+
+- **默认迭代方式**：改源码 → `scripts/dev-run.sh`（沙箱）验证 → 页面刷新
+  （client 半）或 `--restart`（host 半）→ 全绿后才谈部署。
+- **禁止** `cp` 进产品 `profiles/web/node_modules/dsh-remote` 当常规手段：
+  产品 package.json 把 `dsh-remote` 声明为 `^0.5.10`，任何 npm / `dsh plugin`
+  重装都会把手改的文件覆盖回发行版。实证：v0.6.4 部署后 4 小时（8-19 20:48）
+  被重装回 0.5.10 顶掉，本机目录选择器 bug 复发。
+- 产品发布=受控动作：先 git 提交干净基线、跑 `check.mjs` + `boot-smoke.sh`，
+  再 `./sync.sh`，并提醒用户重启桌面后**复查**是否又被重装（若被顶掉，说明
+  触发了一次 plugin 同步，需改产品 profile 依赖声明——属产品模式，先问用户）。
+- 沙箱布局：`dev-harness/harness`（隔离 DSH_HOME）+ 硬链接 profile +
+  `node_modules/dsh-remote` symlink 指向源码目录；数据种子 machines.json /
+  known_hosts.json 从产品拷入一次，之后独立。
+
+## 1. 铁律：框架注册约束，先验证、再写、再守
+
+任何注册到 DSH 框架的名字/结构，**动手前先读安装框架的源码/文档确认合法**，不要猜。
+
+当前已确认的约束（依据桌面版捆绑的 `@deepseek-ai/dsh-commands` 等源码）：
+
+| 注册对象 | 约束 | 违反后果 |
+|---|---|---|
+| `commands.register({name})` | 匹配 `/^[a-z][a-z0-9_-]*$/u`（**无点号/大写/空格/中文**）；`description` 非空字符串；`handler` 返回 `{kind:'success'|'error', text}` | 插件树加载失败 → **桌面无法启动** |
+| Config schema | 用 `@deepseek-ai/schemastery`（非 zod）；叶子避免 `required` 数组（v0.5.7 坑） | 校验/启动异常 |
+| **可选服务访问** | **只准 `ctx.get('serviceName')`**；**禁止 `ctx.<serviceName>` 属性形式**——cordis 要求属性形式必须在插件 `inject` 列表里声明，未声明即抛 `cannot get property "..." without inject`（**与服务是否注册无关**） | 运行时 500 / 功能崩溃（v0.6.4 坑：`ctx.directoryPicker`） |
+| **可选服务可能压根不注册** | `ctx.get('svc')` 只告诉"现在有没有"，**不保证框架服务会挂载**；关键 UX 功能必须自带兜底实现（v0.6.6 实测 `directoryPicker` 在桌面启动路径不注册——web-app 的 `-auto` 行不物化成 loader 条目，即便 `loader.create` 手动挂载服务也不出现） | 功能静默不可用（本机选择器打不开，`ctx.get` 返回 null） |
+| **三方库回调契约以真实运行为准** | 别只信单元测试 mock——mock 会掩盖真实契约漂移（v0.6.1 TOFU 按 ssh2 旧版 `{algo,hash}` 写 hostVerifier，v1.17 实际传**裸 Buffer**，`update(undefined)` 每次连接必崩；测试用 mock 对象全绿）。改依赖/写回调后跑一次真实集成验证 | 功能全挂（v0.6.7：远程浏览 + TOFU 一起救活） |
+| `ctx.get(...)` 依赖 | 按 `inject` 声明白名单，`undefined` 时优雅降级 | 启动崩 |
+| webServer 路由 | 路径注册用框架 API，body 读取有大小上限 | 行为错误/内存 |
+
+**两条 cordis 教训**：命令名不允许点号（v0.6.1，桌面起不来）；可选服务只能
+`ctx.get()` 不能属性直取（v0.6.4，本机目录选择器 500）。`check.mjs` 会静态拦住
+命令名（见 §3）；服务访问靠人工遵守本表。
+
+## 2. 启动期代码必须"fail-safe"
+
+- `apply()` 里所有注册类操作（`commands.register` / `webServer.register`）的输入
+  都要满足框架约束，且能容忍 `ctx.get('commands'/'webServer') === undefined`。
+- 新增任何命令/路由/service 前：先读框架对应 `lib/index.js` 的
+  `normalizeDefinition` / 注册校验逻辑，确认字段、返回值结构、命名规则。
+- 不确定的注册，宁可先 `node --check` + 启动冒烟验证，也不要"先部署试试"。
+
+## 3. 发布流程（宿主半改动必走）
+
+```
+编辑源码
+  → node --check lib/index.js                  （语法）
+  → node check.mjs                             （框架约束静态闸门，已接入 sync.sh）
+  → 涉及行为改动：test/ 下单测（源码提取函数体 + mock，防漂移）
+  → ./sync.sh                                  （拷贝前自动跑 check.mjs；拷贝后自动跑启动冒烟）
+      · 部署后自检 lib 与源码逐字节一致
+      · scripts/boot-smoke.sh：隔离 DSH_HOME + 硬链接拷贝 profile，
+        起桌面 harness 验证"插件树能加载、无 DSH entry failed"
+  → 重启 DSH Desktop，验证功能生效
+```
+
+**关键**：改完宿主半后，**必须**跑 `scripts/boot-smoke.sh`（sync.sh 会自动跑）。
+启动冒烟是最后一道防线——它能在不重启你正在用的桌面实例的前提下，证明改动
+不会让桌面起不来。
+
+## 4. 回滚与备份
+
+- 每次发布前 git commit 一个干净基线；出问题立即 `git checkout` 上一版再 `./sync.sh`。
+- 保持"上一版可启动"始终可用：不要连续多次破坏性改动不验证。
+
+## 5. 记住
+
+- **部署 ≠ 生效**：宿主半要重启桌面才生效；`boot-smoke` 测的是"能加载"，不等于"功能对"。
+- **别猜框架**：`commands.register` 的命令名不允许点号——这是用桌面起不来的代价换来的教训。

--- a/sync.sh
+++ b/sync.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# dsh-remote —— 开发同步脚本（桌面版 Harness 专用）
+#
+# 零构建插件：宿主半 lib/index.js 由 cordis Loader 直接加载，
+# 浏览器半 lib/client.js 由 dsh-client-modules 直接提供。
+# 编辑源码后把 lib/（+ 补丁/清单）同步到 DSH 实际加载的安装目录即可生效。
+#
+# 用法：
+#   ./sync.sh                    # 同步到桌面版 web profile（默认）
+#   TARGET=cli ./sync.sh         # 同步到独立 CLI 的 web profile（~/.dsh/profiles/web）
+#   PROFILE=xxx ./sync.sh        # 指定其他 profile 名
+#
+# ⚠️ 重要（v0.6.5 起）：这是**部署到产品**的脚本，日常迭代请勿直接用。
+#   产品 profile 的 package.json 把 dsh-remote 声明为 `^0.5.10`，任何
+#   npm / dsh plugin 重装都会把这里手工同步的文件覆盖回发行版
+#   （v0.6.4 曾被重装回 0.5.10 顶掉的实证）。日常开发请用沙箱：
+#     scripts/dev-run.sh          # 开发/沙箱模式，改源码即加载，不碰产品
+#   sync.sh 仅用于**用户确认后**的受控发布。
+#
+# 生效方式：
+#   - 宿主半（index.js）：需重启 DSH 进程（桌面版 = 重启 DSH Desktop 应用）
+#   - 浏览器半（client.js）：页面刷新即可（无需重新构建）
+set -euo pipefail
+
+PROFILE="${PROFILE:-web}"
+MODE="${TARGET:-desktop}"
+
+case "$MODE" in
+  desktop)
+    BASE_HOME="${DSH_HOME:-$HOME/Library/Application Support/dsh-desktop/harness}"
+    ;;
+  cli)
+    BASE_HOME="$HOME/.dsh"
+    ;;
+  *)
+    echo "❌ 未知 TARGET: $MODE（可用 desktop | cli）" >&2
+    exit 1
+    ;;
+esac
+
+SRC_DIR="$(cd "$(dirname "$0")" && pwd)"
+INSTALL_DIR="$BASE_HOME/profiles/$PROFILE/node_modules/dsh-remote"
+
+# ── 部署前静态闸门：违反框架约束（如命令名带点号）会搞崩整个桌面 ──
+if [ -f "$SRC_DIR/check.mjs" ]; then
+  echo "⏱  部署前检查 check.mjs …"
+  node "$SRC_DIR/check.mjs" || { echo "❌ 静态检查未通过，中止部署（参考 scripts/dev-standards.md）。" >&2; exit 1; }
+fi
+
+if [ ! -d "$INSTALL_DIR" ]; then
+  echo "❌ 未找到 profile 安装目录: $INSTALL_DIR"
+  echo "   请先执行（在桌面版内）: dsh plugin --profile $PROFILE add dsh-remote"
+  exit 1
+fi
+
+echo "同步 $SRC_DIR/lib → $INSTALL_DIR/lib"
+cp -v "$SRC_DIR"/lib/*.js "$INSTALL_DIR/lib/"
+
+# 顺带同步 cordis 补丁与包清单（幂等）
+for f in cordis.patch.yml package.json; do
+  if [ -f "$SRC_DIR/$f" ]; then
+    cp "$SRC_DIR/$f" "$INSTALL_DIR/$f"
+  fi
+done
+
+# ── 部署后自检（防止"自己把自己搞崩"）──────────────────────────────
+# 1) 部署副本与源码逐字节一致
+if ! diff -rq "$SRC_DIR/lib" "$INSTALL_DIR/lib" >/dev/null; then
+  echo "❌ 自检失败：lib 未与源码一致（可能 cp 被中断）" >&2
+  exit 1
+fi
+if ! diff -q "$SRC_DIR/package.json" "$INSTALL_DIR/package.json" >/dev/null 2>&1; then
+  echo "⚠️  提示：package.json 与源码不一致（未随包清单同步？）"
+fi
+# 2) 启动冒烟测试（隔离 DSH_HOME，验证插件树能加载，不再把桌面搞崩）
+if [ -x "$SRC_DIR/scripts/boot-smoke.sh" ] && [ "${SKIP_SMOKE:-0}" != "1" ]; then
+  "$SRC_DIR/scripts/boot-smoke.sh" || { echo "❌ 启动冒烟失败，已停止部署交付。可用 SKIP_SMOKE=1 跳过（不推荐）。" >&2; exit 1; }
+fi
+
+echo ""
+echo "✅ 已同步 → $INSTALL_DIR"
+echo "   - 宿主半（index.js）改动：重启 DSH Desktop 生效"
+echo "   - 浏览器半（client.js）改动：刷新页面生效"


### PR DESCRIPTION
## What & why

Squashed delivery of the **0.6.x series** (0.6.0 → 0.6.7) onto current main (0.5.10) as one reviewable change. Two headline fixes:

### 1. Local directory picker was dead (0.6.6)
`ctx.get('directoryPicker')` returns **null** at runtime — the `directoryPicker` service is never registered on the desktop boot path (the web-app `-auto` row does not materialize as a loader entry; even `loader.create` of the native backend doesn't surface the service). `/dsh-remote/local-pick` now prefers the service when available, otherwise falls back to the plugin's own native chooser (macOS `osascript` / Linux `zenity`→`kdialog`).

### 2. Remote browse crashed + the TOFU guard was silently broken (0.6.7)
ssh2 v1.17 passes `hostVerifier` a **raw Buffer** (the host-key blob), not the old `{algo, hash}` object the 0.6.1 TOFU guard was written against — so `keyFingerprint` crashed on **every** SSH connect (`The "data" argument must be of type string ... Received undefined`), which is exactly what browsing the remote directory picker hit. It now accepts the raw blob (SHA-256 over the whole blob) or `{algo,hash}`; `blobAlgorithm` parses the algorithm name. Verified against a real host: browse works, known_hosts records `ssh-ed25519`, a changed key is rejected with a MITM alarm + `/remote forget-key` hint.

### Also in this MR
- 0.6.0 cross-platform POSIX commands / timeout SIGTERM / SshPool epoch race guard / incremental sync / `rw_search`·`rw_download`·`rw_upload` / `rw_exec` cwd
- 0.6.1 TOFU host-key verification (`hostKeyMode` accept-new·verify·off, known_hosts.json)
- 0.6.2 stat-free `ls -1A -F` listing (survives stuck mounts)
- 0.6.3 valid slash-command name (boot-crash fix)
- 0.6.4 no more `ctx.directoryPicker` property access
- 0.6.5 upstream dropdown fixes + sandbox dev mode (`scripts/dev-run.sh`, dev-standards, `check.mjs` gate)
- docs: sandbox-first dev workflow (README EN/zh), local picker fallback note

## Verified
- Local picker: real dialog E2E (cancel → `{ok,cancelled}`, select → `{ok,path}`)
- Remote browse + TOFU: real host `ls` HTTP 200; first-connect records; reconnect matches; corrupted fingerprint → fresh connect rejected
- `node --check`, `scripts/check.mjs` (command-name gate), isolated-boot smoke all green