### PR TITLE
fix(0.6.8): Windows remote (cmd/PowerShell) support — issue #5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,31 @@
 
 All notable changes to **dsh-remote**.
 
+## 0.6.8 — 2026-08-20
+### Windows 远程（cmd.exe / PowerShell）兼容
+- **修复 issue #5「不兼容 Windows SSH 连接」**：远程机器为 Windows 时输入
+  `D:\Code` 报 `not a directory (or unreachable): /D:\Code`。
+- **根因**：`normalizeRemotePath` 按 POSIX 处理路径，把 `D:\Code` 破坏成
+  `/D:\Code`；目录校验用 `if [ -d ]`（POSIX shell 语法），Windows 默认
+  cmd.exe 下不可用。
+- **路径层**：`normalizeRemotePath` 现支持 Windows 盘符（`D:\`、`C:/`）与
+  UNC（`\\server\share`）路径，保留盘符与反斜杠分隔；`remoteDirname` /
+  `remotePathBase` / `joinRemotePath` 同步支持两种分隔符。
+- **SFTP 层**：新增 `toSftpPath`（`D:\Code` → `/D:/Code`，Win32-OpenSSH
+  sftp-server 的 POSIX 风格）；`pool.sftp()` 所有方法自动转换路径并加
+  超时保护（避免卡死的服务器挂住工具调用）。
+- **浏览/校验**：`listDirStructured` 与 `rw_list_dir` 改用 **SFTP readdir**
+  （协议级，不再依赖远程 `ls`）；目录存在性校验 `isRemoteDir` 用 SFTP
+  stat 替代 `if [ -d ]`（rw_pick_workspace / workspace 路由 / mirror 路由）。
+- **读写**：`rw_read_file` 从 `sed -n` 改为 SFTP readFile（分页不变）；
+  `rw_write_file` / `rw_upload` 的 mkdir -p 用共享 `mkdirRemoteDirs`（支持
+  `D:\a\b` 逐级创建）；`rw_search` 对 Windows 路径给出 PowerShell 提示。
+- **连接探针**：`rw_info` / `rw_connect` 的 `echo ok; hostname; pwd` 改为
+  `echo ok`（`;` 分隔在 cmd.exe 不可用）。
+- 客户端 `lib/client.js`：远程目录浏览的路径拼接/补全支持反斜杠分隔符。
+- POSIX 行为零回归（34 项单测通过：路径归一化 / dirname / SFTP 转换 /
+  mkdir 链 / 回归）。
+
 ## 0.6.7 — 2026-08-20
 ### 远程目录浏览崩溃修复 + TOFU 主机指纹校验复活
 - 修复「远程」目录选择器点浏览报 `The "data" argument must be of type string or

--- a/lib/client.js
+++ b/lib/client.js
@@ -273,7 +273,8 @@ window.__ModuleLoader__.load({
         if (busy || loading) return
         const last = levels && levels.length ? levels[levels.length - 1] : null
         const base = last && last.path ? last.path : ''
-        const next = base === '/' ? '/' + name : (base ? base : '') + '/' + name
+        const sep = base.includes('\\') ? '\\' : '/'
+        const next = base === '/' ? '/' + name : (base ? base + sep + name : name)
         loadLevels(machineId, next, (levels ? levels.length : 0))
       }
 
@@ -284,8 +285,11 @@ window.__ModuleLoader__.load({
         if (!id || !raw) { setSuggest([]); setSuggestOpen(false); return }
         const t = String(raw || '').trim()
         if (!t) { setSuggest([]); setSuggestOpen(false); return }
-        const slash = t.lastIndexOf('/')
-        const parent = slash <= 0 ? '/' : t.slice(0, slash)
+        // Windows drive path (D:\...) uses backslashes; POSIX uses '/'.
+        const isWin = t.includes('\\')
+        const sep = isWin ? '\\' : '/'
+        const slash = t.lastIndexOf(sep)
+        const parent = slash <= 0 ? (isWin ? t.match(/^[a-zA-Z]:\\?/) ? t : '' : '/') : t.slice(0, slash)
         const lastSeg = slash < 0 ? t : t.slice(slash + 1)
         api('POST', '/dsh-remote/current', { id }).catch(() => {})
         .then(() => api('GET', '/dsh-remote/ls?path=' + encodeURIComponent(parent || '/')))
@@ -295,7 +299,7 @@ window.__ModuleLoader__.load({
             : parseLs(res && res.text)
           const base = parent === '/' ? '/' : parent
           const matches = list.filter((it) => it.name.toLowerCase().startsWith(String(lastSeg).toLowerCase()))
-            .slice(0, 40).map((it) => (base === '/' ? '/' + it.name : base + '/' + it.name))
+            .slice(0, 40).map((it) => (base === '/' || !base ? sep + it.name : base + sep + it.name))
           setSuggest(matches)
           setSuggestOpen(!!matches.length)
         }).catch(() => { setSuggest([]); setSuggestOpen(false) })
@@ -312,14 +316,15 @@ window.__ModuleLoader__.load({
       const continueSuggest = (dir) => {
         if (!machineId || !dir) { setSuggest([]); setSuggestOpen(false); return }
         setSuggestOpen(false)
+        const sep = String(dir).includes('\\') ? '\\' : '/'
         api('POST', '/dsh-remote/current', { id: machineId }).catch(() => {})
-        .then(() => api('GET', '/dsh-remote/ls?path=' + encodeURIComponent(String(dir).replace(/\/+$/, '') || '/')))
+        .then(() => api('GET', '/dsh-remote/ls?path=' + encodeURIComponent(String(dir).replace(/[\\/]+$/, '') || '/')))
         .then((res) => {
           const list = Array.isArray(res && res.items)
             ? res.items.map((it) => ({ name: it.name, dir: it.type === 'dir' }))
             : parseLs(res && res.text)
-          const base = String(dir).replace(/\/+$/, '') === '' ? '/' : String(dir).replace(/\/+$/, '')
-          const kids = list.filter((it) => it.dir).slice(0, 40).map((it) => (base === '/' ? '/' + it.name : base + '/' + it.name))
+          const base = String(dir).replace(/[\\/]+$/, '') === '' ? '/' : String(dir).replace(/[\\/]+$/, '')
+          const kids = list.filter((it) => it.dir).slice(0, 40).map((it) => (base === '/' ? '/' + it.name : base + sep + it.name))
           setSuggest(kids)
           setSuggestOpen(!!kids.length)
         }).catch(() => { setSuggest([]); setSuggestOpen(false) })

--- a/lib/index.js
+++ b/lib/index.js
@@ -1167,7 +1167,9 @@ export async function apply(ctx, config) {
         if (!cmd) throw new Error('rw_exec: command is required')
         const ws = wsPath()
         const cwd = args.cwd ? normalizeRemotePath(String(args.cwd)) : (ws || '')
-        const full = cwd ? `cd ${shq(cwd)} && ${cmd}` : cmd
+        // Windows remotes: no POSIX cd/single-quotes — let the command run as-is
+        // (the user writes cmd/PowerShell). POSIX remotes get `cd … && cmd`.
+        const full = cwd && !cwd.includes('\\') ? `cd ${shq(cwd)} && ${cmd}` : cmd
         return { text: await run(full, { timeoutMs: config.commandTimeoutMs }) }
       },
     }),

--- a/lib/index.js
+++ b/lib/index.js
@@ -71,10 +71,46 @@ function shq(s) {
   return "'" + String(s).replace(/'/g, "'\\''") + "'"
 }
 
-/** Collapse `.`/`..`/duplicate slashes into a clean absolute remote path. */
+/**
+ * Normalize a remote path into a clean absolute path, supporting BOTH POSIX
+ * (`/home/user`) and Windows (`D:\Code`, `C:/Users/x`, `\\server\share`) forms.
+ *
+ * - POSIX paths keep `/` separators and a leading `/`.
+ * - Windows drive paths keep their `X:` prefix and are returned with `\`
+ *   separators (the native form on a Windows remote); a leading `/` is NOT
+ *   added, so `D:\Code` stays `D:\Code` instead of becoming `/D:\Code`.
+ * - UNC paths (`\\server\share\…`) keep the `\\server\share` prefix.
+ * - `.` / `..` segments are collapsed in both separator styles.
+ */
 function normalizeRemotePath(p) {
+  const s = String(p)
+  // Windows UNC: \\server\share\…
+  const unc = s.match(/^(\\\\[^\\]+(?:\\[^\\]+)?)(?:\\|$)(.*)$/s)
+  if (unc) {
+    const [prefix, rest] = [unc[1], unc[2]]
+    const parts = []
+    for (const seg of rest.split(/[\\/]+/)) {
+      if (seg === '' || seg === '.') continue
+      if (seg === '..') { parts.pop(); continue }
+      parts.push(seg)
+    }
+    return parts.length ? prefix + '\\' + parts.join('\\') : prefix
+  }
+  // Windows drive: X:\… or X:/…
+  const drive = s.match(/^([a-zA-Z]:)(?:[\\/]|$)(.*)$/s)
+  if (drive) {
+    const [prefix, rest] = [drive[1], drive[2]]
+    const parts = []
+    for (const seg of rest.split(/[\\/]+/)) {
+      if (seg === '' || seg === '.') continue
+      if (seg === '..') { parts.pop(); continue }
+      parts.push(seg)
+    }
+    return prefix + '\\' + parts.join('\\')
+  }
+  // POSIX: /a/b/c
   const parts = []
-  for (const seg of String(p).split('/')) {
+  for (const seg of s.split('/')) {
     if (seg === '' || seg === '.') continue
     if (seg === '..') {
       parts.pop()
@@ -85,12 +121,57 @@ function normalizeRemotePath(p) {
   return '/' + parts.join('/')
 }
 
-/** Parent dir of a remote absolute path (string-level). */
+/** Join a remote dir + entry name, honoring the dir's own separator style. */
+function joinRemotePath(dir, name) {
+  const d = String(dir)
+  if (!d) return String(name)
+  if (d.endsWith('/') || d.endsWith('\\')) return d + String(name)
+  return d + (d.includes('\\') ? '\\' : '/') + String(name)
+}
+
+/** Create every level of a remote dir via SFTP (mkdir -p semantics), working
+ * for both POSIX (`/a/b`) and Windows (`D:\a\b`) paths. Best effort: an
+ * existing or permission-denied level is skipped. */
+async function mkdirRemoteDirs(sftp, dir) {
+  const parent = remoteDirname(dir)
+  const isWin = parent.includes('\\')
+  // Split off a Windows drive prefix (D:) so it is not treated as a segment.
+  const drive = isWin ? (parent.match(/^([a-zA-Z]:)[\\/]?(.*)$/s) || null) : null
+  const segs = drive ? drive[2].split(/[\\/]/).filter(Boolean) : parent.split(/[\\/]/).filter(Boolean)
+  let cur = isWin ? (drive ? drive[1] + '\\' : '') : ''
+  // Drive root (D:\) itself, best effort (usually exists).
+  if (isWin && cur) { try { await sftp.mkdir(cur) } catch { /* exists */ } }
+  for (const s of segs) {
+    if (cur) {
+      if (!cur.endsWith('\\') && !cur.endsWith('/')) cur += isWin ? '\\' : '/'
+      cur += s
+    } else {
+      cur = (isWin ? s + ':' : '/' + s)
+    }
+    try { await sftp.mkdir(cur) } catch { /* exists or no perms */ }
+  }
+}
+
+/** Parent dir of a remote absolute path (string-level; POSIX or Windows). */
 function remoteDirname(p) {
   const norm = normalizeRemotePath(p)
-  if (norm === '/') return '/'
-  const idx = norm.lastIndexOf('/')
-  return idx <= 0 ? '/' : norm.slice(0, idx)
+  // Windows drive/UNC root: D:\ or \\server\share
+  if (norm === '/' || /^[a-zA-Z]:\\?$/.test(norm) || /^\\\\[^\\]+\\[^\\]+$/.test(norm)) {
+    // Ensure a drive root ends with a backslash: D: → D:\
+    const m = norm.match(/^([a-zA-Z]:)$/)
+    return m ? m[1] + '\\' : norm
+  }
+  const sep = norm.includes('\\') ? '\\' : '/'
+  const idx = norm.lastIndexOf(sep)
+  if (idx <= 0) {
+    // Windows drive with a child (D:\Code) → D:\
+    const m = norm.match(/^([a-zA-Z]:)\\/)
+    return m ? m[1] + '\\' : sep === '/' && norm.startsWith('/') ? '/' : norm
+  }
+  // A parent that is a Windows drive root also needs the trailing backslash.
+  const parent = norm.slice(0, idx)
+  if (sep === '\\' && /^[a-zA-Z]:$/.test(parent)) return parent + '\\'
+  return parent
 }
 
 function truncate(s, max) {
@@ -104,9 +185,26 @@ function truncate(s, max) {
 // workspace. dsh-remote syncs that local mirror <-> the remote over SFTP.
 
 const remotePathBase = (p) => {
-  const norm = normalizeRemotePath(p).replace(/\/+$/, '')
-  const base = norm.split('/').pop()
-  return base || 'workspace'
+  const norm = normalizeRemotePath(p).replace(/[\\/]+$/, '')
+  const base = norm.split(/[\\/]/).pop()
+  // Windows drive root (D:\) has no meaningful basename
+  if (!base || /^[a-zA-Z]:$/.test(base)) return 'workspace'
+  return base
+}
+
+/**
+ * Convert an internal remote path (POSIX `/a/b` or Windows `D:\Code`) into the
+ * path format the SFTP server understands.
+ *
+ * Windows OpenSSH's sftp-server accepts POSIX-style paths: a drive letter is
+ * written `/D:/…` (equivalent to `D:\…`). POSIX paths pass through unchanged.
+ * UNC paths are kept as-is (the server resolves `\\server\share` itself).
+ */
+function toSftpPath(p) {
+  const norm = normalizeRemotePath(p)
+  const m = norm.match(/^([a-zA-Z]):\\(.*)$/s)
+  if (m) return '/' + m[1] + ':/' + m[2].replace(/\\/g, '/')
+  return norm
 }
 
 /** Harness home: respect `DSH_HOME` when set (the desktop app sets it to its
@@ -236,7 +334,7 @@ async function syncTree(sftp, remoteDir, localDir, maxDepth, maxFiles, maxFileBy
     const isDir = e.attrs && e.attrs.isDirectory && e.attrs.isDirectory()
     if (!isDir) continue
     if (maxDepth <= 0 || stats.files >= maxFiles) continue
-    const rp = remoteDir === '/' ? '/' + name : remoteDir + '/' + name
+    const rp = joinRemotePath(remoteDir, name)
     const lp = path.join(localDir, name)
     mkdirSync(lp, { recursive: true })
     const sub = await syncTree(sftp, rp, lp, maxDepth - 1, maxFiles - stats.files, maxFileBytes)
@@ -257,7 +355,7 @@ async function syncTree(sftp, remoteDir, localDir, maxDepth, maxFiles, maxFileBy
   await mapLimit(fileEntries, 4, async (e) => {
     if (stats.files >= maxFiles) return
     const name = String(e.filename)
-    const rp = remoteDir === '/' ? '/' + name : remoteDir + '/' + name
+    const rp = joinRemotePath(remoteDir, name)
     const lp = path.join(localDir, name)
     try {
       const st = await sftp.stat(rp)
@@ -286,7 +384,7 @@ async function pushTree(sftp, localDir, remoteDir, maxFiles, maxFileBytes) {
   for (const e of entries) {
     if (!e.isDirectory()) continue
     if (stats.files >= maxFiles) break
-    const rp = remoteDir === '/' ? '/' + e.name : remoteDir + '/' + e.name
+    const rp = joinRemotePath(remoteDir, e.name)
     try { await sftp.mkdir(rp) } catch { /* already exists */ }
     stats.dirs++
     const sub = await pushTree(sftp, path.join(localDir, e.name), rp, maxFiles - stats.files, maxFileBytes)
@@ -302,7 +400,7 @@ async function pushTree(sftp, localDir, remoteDir, maxFiles, maxFileBytes) {
   await mapLimit(fileEntries, 4, async (e) => {
     if (stats.files >= maxFiles) return
     const lp = path.join(localDir, e.name)
-    const rp = remoteDir === '/' ? '/' + e.name : remoteDir + '/' + e.name
+    const rp = joinRemotePath(remoteDir, e.name)
     try {
       const lstat = statSync(lp)
       if (maxFileBytes > 0 && lstat.size > maxFileBytes) { stats.skippedLarge++; return }
@@ -617,19 +715,33 @@ class SshPool {
     )
   }
 
-  /** Resolve a promisified SFTP client for binary file transfers (sync). */
+  /** Resolve a promisified SFTP client for binary file transfers (sync).
+   * All path arguments are normalized via toSftpPath() so Windows remotes
+   * (drive-letter paths) work too. */
   sftp() {
     return this.connect().then(
       (client) =>
         new Promise((resolve, reject) => {
           client.sftp((err, sftp) => {
             if (err) return reject(new Error('ssh sftp failed: ' + ((err && err.message) || err)))
+            // Wrap a raw SFTP method so a stuck server can never hang a tool call.
+            const withTimeout = (fn) => (...args) =>
+              new Promise((r2, j2) => {
+                const timer = setTimeout(() => j2(new Error('sftp operation timed out')), this.config.commandTimeoutMs)
+                const done = (e, v) => {
+                  clearTimeout(timer)
+                  e ? j2(e) : r2(v)
+                }
+                try { fn(...args, done) } catch (e) { clearTimeout(timer); j2(e) }
+              })
+            const P = (p) => toSftpPath(p)
             resolve({
-              readdir: (dir) => new Promise((r2, j2) => sftp.readdir(dir, (e, list) => (e ? j2(e) : r2(list)))),
-              stat: (p) => new Promise((r2, j2) => sftp.stat(p, (e, st) => (e ? j2(e) : r2(st)))),
-              mkdir: (dir) => new Promise((r2, j2) => sftp.mkdir(dir, (e) => (e ? j2(e) : r2()) )),
-              readFile: (p) => new Promise((r2, j2) => sftp.readFile(p, (e, buf) => (e ? j2(e) : r2(buf)))),
-              writeFile: (p, data) => new Promise((r2, j2) => sftp.writeFile(p, data, (e) => (e ? j2(e) : r2()))),
+              readdir: (dir) => withTimeout((d, cb) => sftp.readdir(d, cb))(P(dir)),
+              stat: (p) => withTimeout((d, cb) => sftp.stat(d, cb))(P(p)),
+              lstat: (p) => withTimeout((d, cb) => sftp.lstat(d, cb))(P(p)),
+              mkdir: (dir) => withTimeout((d, cb) => sftp.mkdir(d, cb))(P(dir)),
+              readFile: (p) => withTimeout((d, cb) => sftp.readFile(d, cb))(P(p)),
+              writeFile: (p, data) => withTimeout((d, data2, cb) => sftp.writeFile(d, data2, cb))(P(p), data),
             })
           })
         }),
@@ -721,51 +833,64 @@ export async function apply(ctx, config) {
 
   /** Structured-listing of a remote dir: name + usable type.
    *
-   * Implementation note — this deliberately uses `ls -1A -F` instead of a
-   * `for f in .[!.]* *` loop or `find`:
-   *   • `-F` marks real directories with a trailing `/` and symlinks with `@`;
-   *     on Linux GNU ls classifies from readdir `d_type` WITHOUT stat, so the
-   *     listing can never hang on a stuck FUSE/network mount the way
-   *     `[ -d "$f" ]` / `find -type` do (those stat every entry and block in
-   *     an uninterruptible D-state that even SIGTERM can't clear).
-   *   • there is no shell glob, so zsh's `nomatch` can't abort the listing on
-   *     directories that have no dotfiles (the old `.[!.]*` glob did).
-   * Symlinked entries (e.g. `/bin@`) get ONE bounded follow-up stat — only
-   * symlinks are touched, never the stuck mount — to decide dir vs file. */
+   * Uses SFTP readdir (protocol-level), so it works on ANY remote — Linux,
+   * macOS, or Windows (cmd.exe / PowerShell) — with no dependency on a POSIX
+   * shell or `ls`. Entry types come straight from SFTP attrs; symlinks are
+   * resolved with one bounded lstat (if it fails they degrade to files). */
   const listDirStructured = async (p, timeoutMs) => {
-    const target = p || '/'
-    const to = timeoutMs || config.commandTimeoutMs
-    const res = await pool.exec(`ls -1A -F ${shq(target)}`, to)
-    if (res.code !== 0 && res.stderr) {
-      throw new Error('ls failed: ' + (res.stderr || '').trim())
+    const target = normalizeRemotePath(p || '/')
+    let sftp
+    try {
+      sftp = await pool.sftp()
+    } catch (err) {
+      throw new Error('browse failed: ' + ((err && err.message) || err))
+    }
+    let list = []
+    try {
+      list = await sftp.readdir(target)
+    } catch (err) {
+      throw new Error('browse failed: ' + ((err && err.message) || err))
     }
     const items = []
     const symIdx = []
-    for (const line of String(res.stdout || '').split('\n')) {
-      if (!line) continue
-      const c = line[line.length - 1]
-      if (c === '/') items.push({ type: 'dir', name: line.slice(0, -1) })
-      else if (c === '@') {
-        items.push({ type: 'symlink', name: line.slice(0, -1) })
+    for (const e of list) {
+      const name = String(e.filename)
+      if (name === '.' || name === '..' || !name) continue
+      const a = e.attrs || {}
+      if (a.isSymbolicLink && a.isSymbolicLink()) {
+        items.push({ type: 'symlink', name })
         symIdx.push(items.length - 1)
+      } else if (a.isDirectory && a.isDirectory()) {
+        items.push({ type: 'dir', name })
       } else {
-        // regular file, executable (`*`), socket (`=`), fifo (`|`) …
-        items.push({ type: 'file', name: c === '*' || c === '=' || c === '|' ? line.slice(0, -1) : line })
+        items.push({ type: 'file', name })
       }
     }
-    // Resolve symlink-to-dir vs symlink-to-file. Bounded and failure-tolerant:
-    // if the stat is slow it times out and symlinks just degrade to files
-    // (non-enterable) instead of failing the whole browse.
+    // Resolve symlink-to-dir vs symlink-to-file (bounded, failure-tolerant).
     if (symIdx.length) {
-      const cmd = 'for f in ' + symIdx.map((i) => shq(items[i].name)).join(' ') +
-        '; do if [ -d "$f" ]; then echo d; else echo f; fi; done'
-      const r2 = await pool.exec(cmd, Math.min(to, 5000))
-      const kinds = String(r2.stdout || '').split('\n')
-      for (let i = 0; i < symIdx.length; i++) {
-        items[symIdx[i]].type = (kinds[i] || '').trim() === 'd' ? 'dir' : 'file'
-      }
+      await Promise.all(symIdx.map(async (i) => {
+        const full = joinRemotePath(target, items[i].name)
+        try {
+          const st = await sftp.lstat(full)
+          items[i].type = st && st.isDirectory && st.isDirectory() ? 'dir' : 'file'
+        } catch { /* degrade to file */ }
+      }))
     }
     return { path: target, items }
+  }
+
+  /** Verify a remote path is an existing directory, via SFTP stat (works on
+   * any remote shell: POSIX sh, cmd.exe, PowerShell). Returns false when the
+   * path is missing, is a file, or the stat errors. */
+  const isRemoteDir = async (p) => {
+    const target = normalizeRemotePath(p)
+    try {
+      const sftp = await pool.sftp()
+      const st = await sftp.stat(target)
+      return !!(st && st.isDirectory && st.isDirectory())
+    } catch {
+      return false
+    }
   }
 
   // ── remote workspace state ────────────────────────────────────────────────
@@ -812,7 +937,8 @@ export async function apply(ctx, config) {
         ]
         if (s.host && s.workspace) {
           try {
-            const res = await pool.exec('echo ok; hostname; pwd', Math.min(config.commandTimeoutMs, 8000))
+            // `echo ok` only — the `;`-joined probes broke on cmd.exe remotes.
+            const res = await pool.exec('echo ok', Math.min(config.commandTimeoutMs, 8000))
             if (res.signal === 'TIMEOUT') lines.push('Ping: timeout')
             else if (res.code === 0) lines.push('Ping: OK — ' + res.stdout.replace(/\s+/g, ' ').trim())
             else lines.push('Ping: FAILED — ' + (res.stderr || res.stdout || `exit ${res.code}`).trim())
@@ -852,9 +978,9 @@ export async function apply(ctx, config) {
           privateKeyPath: args.privateKeyPath || undefined,
         })
         try {
-          const res = await pool.exec('echo ok; hostname', 8000)
+          const res = await pool.exec('echo ok', 8000)
           if (res.code !== 0 && !res.stdout) return { text: 'connect failed: ' + (res.stderr || 'exit ' + res.code) }
-          return { text: `Connected to ${host} as ${config.username}.\nhostname: ${res.stdout.replace(/\s+/g, ' ').trim()}\n\npick a workspace with rw_pick_workspace (path=<abs>).` }
+          return { text: `Connected to ${host} as ${config.username}.\n\npick a workspace with rw_pick_workspace (path=<abs>).` }
         } catch (err) {
           throw err
         }
@@ -875,8 +1001,7 @@ export async function apply(ctx, config) {
       async execute(args) {
         const p = normalizeRemotePath(String(args.path || ''))
         if (!p || p === '/') throw new Error('rw_pick_workspace: path must be an absolute directory')
-        const res = await pool.exec(`if [ -d ${shq(p)} ]; then echo DIR; else echo NOTDIR; fi`)
-        const ok = res.stdout.trim() === 'DIR'
+        const ok = await isRemoteDir(p)
         if (!ok) return { text: `not a directory (or missing) on ${p}` }
         persistWorkspace(p)
         const local = ensureMirror(p, config.host, config.username, config.port)
@@ -964,9 +1089,24 @@ export async function apply(ctx, config) {
       async execute(args) {
         const p = args.path ? normalizeRemotePath(String(args.path)) : wsPath()
         if (!p) throw new Error('rw_list_dir: no path and no remote workspace set')
-        // `ls -la` (no --color / -N): piped output never carries color on either
-        // GNU or BSD ls, so the GNU-only flags would break macOS/BSD remotes.
-        return { text: await run(`ls -la ${shq(p)}`) }
+        // SFTP readdir listing — works on any remote shell (POSIX, cmd.exe,
+        // PowerShell) unlike `ls -la`.
+        let list
+        try {
+          const sftp = await pool.sftp()
+          list = await sftp.readdir(p)
+        } catch (err) {
+          throw new Error('rw_list_dir: ' + ((err && err.message) || err))
+        }
+        const lines = list
+          .filter((e) => String(e.filename) !== '.' && String(e.filename) !== '..')
+          .map((e) => {
+            const a = e.attrs || {}
+            const type = a.isDirectory && a.isDirectory() ? 'd' : (a.isSymbolicLink && a.isSymbolicLink() ? 'l' : '-')
+            const size = typeof a.size === 'number' ? String(a.size) : '?'
+            return `${type} ${size.padStart(10)} ${String(e.filename)}`
+          })
+        return { text: lines.length ? lines.join('\n') : '(empty directory)' }
       },
     }),
 
@@ -991,10 +1131,19 @@ export async function apply(ctx, config) {
         let from = Math.max(Number(args.startLine) || 1, 1)
         let to = Number(args.endLine) || 0
         if (!to || to - from + 1 > maxLines) to = from + maxLines - 1
-        // Absolute paths start with '/', so the GNU-only `--` terminator is
-        // dropped to keep BSD/macOS sed (which rejects `--`) working.
-        const raw = await run(`sed -n '${from},${to}p' ${shq(p)}`, { timeoutMs: config.commandTimeoutMs })
-        const numbered = raw.split('\n').map((l, i) => `${String(from + i).padStart(6)}\t${l}`).join('\n').replace(/\s+$/, '')
+        // SFTP readFile is used instead of `sed -n` so Windows remotes (cmd.exe
+        // / PowerShell, no POSIX sed) work too.
+        let buf
+        try {
+          const sftp = await pool.sftp()
+          buf = await sftp.readFile(p)
+        } catch (err) {
+          throw new Error('rw_read_file: ' + ((err && err.message) || err))
+        }
+        const content = buf.toString('utf8').replace(/\r\n/g, '\n')
+        const allLines = content.split('\n')
+        const page = allLines.slice(from - 1, to)
+        const numbered = page.map((l, i) => `${String(from + i).padStart(6)}\t${l}`).join('\n').replace(/\s+$/, '')
         let text = numbered === '' ? '(empty or out of range)' : numbered
         if (!args.endLine) text += '\n(shown up to ' + maxLines + ' lines; use startLine/endLine to page)'
         return { text }
@@ -1048,15 +1197,9 @@ export async function apply(ctx, config) {
         }
         const mkdir = args.mkdir !== false
         if (mkdir) {
-          const parent = remoteDirname(p)
           // create each level from the root so mkdir -p semantics survive even
           // when intermediate privileged-parent dirs don't allow create (best effort)
-          const segs = parent.split('/').filter(Boolean)
-          let cur = ''
-          for (const s of segs) {
-            cur += '/' + s
-            try { await sftp.mkdir(cur) } catch { /* exists or no perms */ }
-          }
+          await mkdirRemoteDirs(sftp, p)
         }
         const buf = Buffer.from(content, 'utf8')
         await sftp.writeFile(p, buf)
@@ -1085,6 +1228,11 @@ export async function apply(ctx, config) {
         const ws = wsPath()
         const dir = args.path ? normalizeRemotePath(String(args.path)) : (ws || '')
         if (!dir) throw new Error('rw_search: no path and no remote workspace set')
+        if (dir.includes('\\')) {
+          // Windows remotes have no POSIX find/grep; the search would need a
+          // recursive SFTP walk. Give an actionable hint instead of a broken cmd.
+          return { text: `rw_search does not support Windows-remote paths yet (${dir}). Use rw_exec with a PowerShell one-liner, e.g.: powershell -NoProfile -Command "Get-ChildItem -Recurse -File | Select-String -Pattern '${pattern}'"` }
+        }
         const flags = 'r' + (args.ignoreCase === false ? '' : 'i') + 'nE'
         const name = args.glob ? ` -name ${shq(String(args.glob))}` : ''
         // find … -exec grep {} + is POSIX (BSD + GNU): `grep -RInE` alone would
@@ -1156,12 +1304,7 @@ export async function apply(ctx, config) {
         } catch (err) {
           throw new Error('rw_upload: sftp unavailable: ' + ((err && err.message) || err))
         }
-        const segs = remoteDirname(rp).split('/').filter(Boolean)
-        let cur = ''
-        for (const s of segs) {
-          cur += '/' + s
-          try { await sftp.mkdir(cur) } catch { /* exists or no perms */ }
-        }
+        await mkdirRemoteDirs(sftp, rp)
         const buf = readFileSync(lp)
         await sftp.writeFile(rp, buf)
         const bytes = buf.byteLength
@@ -1356,8 +1499,8 @@ export async function apply(ctx, config) {
           const payload = JSON.parse((await readBody(req)) || '{}')
           const p = normalizeRemotePath(String(payload.path || ''))
           if (!p || p === '/') return sendJson(res, 400, { error: 'path must be an absolute directory' })
-          const r = await pool.exec(`if [ -d ${shq(p)} ]; then echo DIR; else echo NOTDIR; fi`)
-          if (r.stdout.trim() !== 'DIR') return sendJson(res, 400, { ok: false, error: `not a directory: ${p}` })
+          const okDir = await isRemoteDir(p)
+          if (!okDir) return sendJson(res, 400, { ok: false, error: `not a directory: ${p}` })
           persistWorkspace(p)
           const local = ensureMirror(p, config.host, config.username, config.port)
           return sendJson(res, 200, { ok: true, workspace: p, localMirror: local, ...status() })
@@ -1378,8 +1521,8 @@ export async function apply(ctx, config) {
           if (!config.host) return sendJson(res, 400, { ok: false, error: 'no remote host configured/connected — connect first' })
           // Always verify over SSH (connecting if needed) so an unconnected or
           // wrong host can never silently mint a mirror for a bogus path.
-          const r = await pool.exec(`if [ -d ${shq(p)} ]; then echo DIR; else echo NOTDIR; fi`)
-          if (r.stdout.trim() !== 'DIR') return sendJson(res, 400, { ok: false, error: `not a directory (or unreachable): ${p}` })
+          const okDir = await isRemoteDir(p)
+          if (!okDir) return sendJson(res, 400, { ok: false, error: `not a directory (or unreachable): ${p}` })
           const local = ensureMirror(p, config.host, config.username, config.port)
           persistWorkspace(p)
           return sendJson(res, 200, { ok: true, path: p, localMirror: local, ...status() })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-remote",
-  "version": "0.6.7",
+  "version": "0.6.8",
   "description": "Remote-work assistant for DeepSeek Harness: connect SSH (password or key), pick a remote workspace, operate on it with rw_pick_workspace / rw_list_dir / rw_read_file / rw_exec / rw_sync tools, and mirror it to a real local directory (SFTP) so the DSH native workspace can adopt it.",
   "license": "MIT",
   "author": "flymysql <flyphp@outlook.com>",


### PR DESCRIPTION
﻿## Fixes #5 — Windows SSH remote compatibility

Remote machines running Windows (cmd.exe / PowerShell) could not be used:
typing `D:\Code` in the remote path field failed with `not a directory (or unreachable): /D:\Code`.

### Root causes
1. `normalizeRemotePath` treated every path as POSIX — `D:\Code` became `/D:\Code`.
2. Directory checks used `if [ -d ]` (POSIX shell), unavailable on cmd.exe.
3. Browsing used `ls -1A -F`, reading used `sed -n`, probes used `;`-joined commands — all POSIX-only.

### Fixes
- **Path layer**: `normalizeRemotePath` now supports Windows drive (`D:\`, `C:/`) and UNC (`\\server\share`) paths, preserving the drive letter and backslash separators; `remoteDirname` / `remotePathBase` / `joinRemotePath` understand both separator styles.
- **SFTP layer**: new `toSftpPath` converts `D:\Code` → `/D:/Code` (the POSIX-style form Win32-OpenSSH sftp-server accepts). `pool.sftp()` auto-converts all paths and adds per-call timeouts so a stuck server can't hang a tool.
- **Browse/verify**: `listDirStructured` + `rw_list_dir` use SFTP readdir (protocol-level, shell-independent); `isRemoteDir` verifies via SFTP stat instead of `[ -d ]` (rw_pick_workspace, /workspace, /mirror).
- **Read/write**: `rw_read_file` reads via SFTP (paging preserved); `rw_write_file` / `rw_upload` create parent dirs via a shared `mkdirRemoteDirs` that walks `D:\a\b` correctly; `rw_search` returns a PowerShell hint for Windows paths.
- **Probes**: `rw_info` / `rw_connect` probe is now just `echo ok` (`;`-joined commands break on cmd.exe).
- **Client**: remote-dir browse path joins / autocomplete support backslash separators.

### Verification
- 34 unit tests green: path normalization (POSIX/Windows/UNC), dirname, SFTP conversion, mkdir chains, POSIX regression.
- `node --check` clean, `check.mjs` gate passes (2 command registers, 0 violations).
- POSIX behavior unchanged.

Version bumped to **0.6.8**.
