### PR TITLE
fix: honor the browse directory-picker backend for local folder picking

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -436,6 +436,9 @@ window.__ModuleLoader__.load({
       const [suggest, setSuggest] = React.useState([])
       const [suggestOpen, setSuggestOpen] = React.useState(false)
       const [recent, setRecent] = React.useState([])
+      // 本机浏览浮层（browse 后端）：{ path, home, crumbs, entries, truncated }。
+      const [localPop, setLocalPop] = React.useState(null)
+      const [newDirName, setNewDirName] = React.useState('')
       const suggestTimer = React.useRef(null)
       const suggestRef = React.useRef(null)
       React.useEffect(() => {
@@ -485,6 +488,7 @@ window.__ModuleLoader__.load({
       }
 
       React.useEffect(() => { if (open) {
+        setLocalPop(null); setNewDirName('')
         api('GET', '/dsh-remote/machines').then((r) => {
           setMachines(r.machines || [])
           const cur = (r.machines || []).find((m) => m.id === r.currentId)
@@ -493,16 +497,45 @@ window.__ModuleLoader__.load({
         })
       } }, [open])
 
+      // 本机目录浏览（browse 后端）：列出 path 的子目录；path 为空 → 宿主家目录。
+      const loadLocal = (p) => {
+        setLoading(true); setErr('')
+        api('GET', '/dsh-remote/local-list' + (p ? '?path=' + encodeURIComponent(p) : ''))
+          .then((r) => setLocalPop({ path: (r && r.path) || p || '', home: (r && r.home) || '', crumbs: (r && r.crumbs) || [], entries: (r && r.entries) || [], truncated: !!(r && r.truncated) }))
+          .catch((e) => setErr(String((e && e.message) || e)))
+          .finally(() => setLoading(false))
+      }
+
       const chooseLocal = () => {
         setLoading(true); setErr('')
         api('POST', '/dsh-remote/local-pick')
           .then((r) => {
-            if (r && r.path) onPicked(String(r.path))
-            else if (r && r.cancelled) setErr('已取消选择')
-            else setErr((r && r.error) || '无法打开系统文件夹选择器，可直接在输入框填本地路径')
+            if (r && r.path) { setLoading(false); onPicked(String(r.path)) }
+            // browse 后端（DSH Desktop / 无显示的远程宿主）：没有 OS 对话框可开
+            // → 打开内置本机目录浏览器。
+            else if (r && r.kind === 'browse') loadLocal('')
+            else if (r && r.cancelled) { setLoading(false); setErr('已取消选择') }
+            else { setLoading(false); setErr((r && r.error) || '无法打开系统文件夹选择器，可直接在输入框填本地路径') }
           })
-          .catch((e) => setErr(String((e && e.message) || e) + ' — 可直接在输入框填本地路径'))
-          .finally(() => setLoading(false))
+          .catch((e) => { setLoading(false); setErr(String((e && e.message) || e) + ' — 可直接在输入框填本地路径') })
+      }
+
+      // 在浮层当前目录下新建文件夹（browse 后端 createDirectory），成功后刷新列表。
+      const mkdirLocal = () => {
+        const cur = localPop
+        const name = newDirName.trim()
+        if (!cur || !cur.path || !name || loading) return
+        setLoading(true); setErr('')
+        api('POST', '/dsh-remote/local-mkdir', { path: cur.path, name })
+          .then(() => { setNewDirName(''); loadLocal(cur.path) })
+          .catch((e) => { setErr(String((e && e.message) || e)); setLoading(false) })
+      }
+
+      // 选用浮层中的本机目录：回填输入框（不直接提交），复核后再点「选用此本地路径」。
+      const acceptLocalPick = (p) => {
+        setPath(String(p || ''))
+        setErr('')
+        setLocalPop(null)
       }
 
       const switchTab = (t) => {
@@ -612,6 +645,64 @@ window.__ModuleLoader__.load({
           .catch((e) => setErr(String((e && e.message) || e)))
       }
 
+      // 本机浏览浮层的面包屑：browse 后端给出完整祖先链（含盘符根），可点击跳转。
+      const localCrumbs = (cur) => {
+        const crumbs = (cur && cur.crumbs) || []
+        if (!crumbs.length) return React.createElement('span', null, '/')
+        const out = []
+        crumbs.forEach((c, i) => {
+          if (i > 0) out.push(React.createElement('span', { key: 'sep' + i, style: { color: T.muted } }, ' › '))
+          out.push(React.createElement('span', {
+            key: c.path || i,
+            title: c.path,
+            onClick: () => loadLocal(c.path),
+            style: { cursor: 'pointer', color: i === crumbs.length - 1 ? T.label : T.ok, fontWeight: i === crumbs.length - 1 ? 700 : 400 },
+          }, c.name))
+        })
+        return React.createElement('span', null, out)
+      }
+
+      // 本机目录浏览浮层（browse 后端）：进入子目录 / 面包屑跳转 / 回家目录 /
+      // 新建文件夹 / 选用回填。与远程浏览弹层同一套交互。
+      function renderLocalPopup() {
+        const cur = localPop
+        if (!cur) return null
+        const crumbs = cur.crumbs || []
+        const parent = crumbs.length >= 2 ? crumbs[crumbs.length - 2].path : null
+        return React.createElement('div', {
+          style: { position: 'fixed', inset: 0, zIndex: 9999, background: 'rgba(0,0,0,0.5)', display: 'flex', alignItems: 'center', justifyContent: 'center', padding: 12 },
+          onClick: () => setLocalPop(null),
+        },
+          React.createElement('div', { style: { background: v('--dsw-alias-bg-overlay', '#1e1e1e'), border: '1px solid ' + T.borderStrong, borderRadius: 10, boxShadow: '0 10px 40px rgba(0,0,0,0.5)', width: 'min(560px, 94vw)', minWidth: 320, display: 'flex', flexDirection: 'column', maxHeight: 'min(460px, 84vh)', overflow: 'hidden' }, onClick: (e) => e.stopPropagation() },
+            React.createElement('div', { style: { display: 'flex', gap: 6, alignItems: 'center', padding: '8px 12px', borderBottom: '1px solid ' + T.border } },
+              React.createElement('button', { style: { ...buttonS, padding: '3px 10px' }, onClick: () => parent && loadLocal(parent), disabled: !parent || loading, title: parent || '' }, '回上一级 ▴'),
+              cur.home ? React.createElement('button', { style: { ...buttonS, padding: '3px 8px' }, onClick: () => loadLocal(cur.home), disabled: loading, title: cur.home }, '🏠') : null,
+              React.createElement('div', { style: { fontSize: 11, opacity: 0.75, fontFamily: 'monospace', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flex: 1 } }, localCrumbs(cur)),
+              React.createElement('button', { style: { ...buttonS, padding: '3px 10px' }, onClick: () => setLocalPop(null) }, '关闭 ✕'),
+            ),
+            React.createElement('div', { style: { overflowY: 'auto', overflowX: 'hidden' } },
+              loading ? React.createElement('div', { style: { opacity: 0.7, padding: 12 } }, '加载中…')
+                : (cur.entries.length ? cur.entries.slice(0, 400).map((it, i) => React.createElement('div', {
+                    key: it.path || i, title: '进入 ' + it.name,
+                    onClick: () => loadLocal(it.path),
+                    style: { padding: '7px 12px', cursor: 'pointer', color: T.label, whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis', display: 'flex', gap: 8, alignItems: 'center', fontSize: 13, borderBottom: '1px solid ' + T.border },
+                  },
+                    React.createElement('span', null, '📁'),
+                    React.createElement('span', { style: { overflow: 'hidden', textOverflow: 'ellipsis' } }, it.name),
+                  )) : React.createElement('div', { style: { opacity: 0.6, padding: 12 } }, '（没有子目录 — 可直接选用当前目录）')),
+              cur.truncated ? React.createElement('div', { style: { opacity: 0.6, padding: '6px 12px', fontSize: 11 } }, '（条目过多已截断 — 其他盘/路径可直接在输入框填写）') : null,
+            ),
+            err ? React.createElement('div', { style: { color: T.danger, fontSize: 12, padding: '4px 12px' } }, err) : null,
+            React.createElement('div', { style: { display: 'flex', gap: 6, alignItems: 'center', padding: '8px 12px', borderTop: '1px solid ' + T.border } },
+              React.createElement('input', { value: newDirName, onChange: (e) => setNewDirName(e.target.value), placeholder: '新建文件夹', style: { ...inputS, width: 110, flex: '0 0 auto', padding: '4px 8px', fontSize: 12 } }),
+              React.createElement('button', { style: { ...buttonS, padding: '4px 10px', whiteSpace: 'nowrap' }, onClick: mkdirLocal, disabled: loading || !newDirName.trim() || !cur.path }, '新建'),
+              React.createElement('span', { style: { fontSize: 11, opacity: 0.75, fontFamily: 'monospace', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flex: 1 } }, '所选: ' + cur.path),
+              React.createElement('button', { style: { ...buttonS, fontWeight: 600, whiteSpace: 'nowrap' }, onClick: () => acceptLocalPick(cur.path) }, '选用此路径'),
+            ),
+          ),
+        )
+      }
+
       function renderDirPopup() {
         if (!levels || !levels.length) {
           return React.createElement('div', { style: { opacity: 0.6, fontSize: 12 } }, (loading ? '加载中…' : '正在读取根目录…'))
@@ -660,13 +751,14 @@ window.__ModuleLoader__.load({
         ),
         tab === 'local'
           ? React.createElement('div', { style: { display: 'flex', flexDirection: 'column', gap: 8 } },
-              React.createElement('div', { style: { fontSize: 12, opacity: 0.8 } }, '系统选择器优先；不可用时直接输入本机目录。'),
+              React.createElement('div', { style: { fontSize: 12, opacity: 0.8 } }, '系统选择器优先；桌面版/远程宿主用内置目录浏览，也可直接输入本机目录。'),
               React.createElement('div', { style: { display: 'flex', gap: 6 } },
                 React.createElement('input', { value: path, onChange: (e) => setPath(e.target.value), placeholder: '本机目录，如 C:\\Users\\you\\project', style: inputS }),
                 React.createElement('button', { style: buttonS, onClick: () => (path.trim() ? onPicked(path) : undefined), disabled: !path.trim() }, '选用此本地路径'),
               ),
-              React.createElement('button', { style: { ...buttonS, alignSelf: 'flex-start' }, onClick: chooseLocal, disabled: loading }, loading ? '打开中…' : '打开系统文件夹选择器'),
+              React.createElement('button', { style: { ...buttonS, alignSelf: 'flex-start' }, onClick: chooseLocal, disabled: loading }, loading ? '打开中…' : '打开文件夹选择器'),
               err ? React.createElement('div', { style: { color: T.danger, fontSize: 12 } }, err) : null,
+              localPop ? renderLocalPopup() : null,
             )
           : React.createElement('div', { style: { display: 'flex', flexDirection: 'column', gap: 8, minHeight: 0, overflowY: 'auto' } },
               React.createElement('div', { style: { display: 'flex', gap: 6, alignItems: 'center' } },

--- a/lib/client.js
+++ b/lib/client.js
@@ -497,11 +497,11 @@ window.__ModuleLoader__.load({
         })
       } }, [open])
 
-      // 本机目录浏览（browse 后端）：列出 path 的子目录；path 为空 → 宿主家目录。
+      // 本机目录浏览（browse 后端兜底）：列出 path 的子目录；path 为空 → 宿主家目录。
       const loadLocal = (p) => {
         setLoading(true); setErr('')
         api('GET', '/dsh-remote/local-list' + (p ? '?path=' + encodeURIComponent(p) : ''))
-          .then((r) => setLocalPop({ path: (r && r.path) || p || '', home: (r && r.home) || '', crumbs: (r && r.crumbs) || [], entries: (r && r.entries) || [], truncated: !!(r && r.truncated) }))
+          .then((r) => setLocalPop({ path: (r && r.path) || p || '', home: (r && r.home) || '', crumbs: (r && r.crumbs) || [], entries: (r && r.entries) || [], truncated: !!(r && r.truncated), drives: (r && r.drives) || [] }))
           .catch((e) => setErr(String((e && e.message) || e)))
           .finally(() => setLoading(false))
       }
@@ -680,6 +680,19 @@ window.__ModuleLoader__.load({
               React.createElement('div', { style: { fontSize: 11, opacity: 0.75, fontFamily: 'monospace', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', flex: 1 } }, localCrumbs(cur)),
               React.createElement('button', { style: { ...buttonS, padding: '3px 10px' }, onClick: () => setLocalPop(null) }, '关闭 ✕'),
             ),
+            // 盘符切换行（Windows 无统一根目录，browse 面包屑到不了其他盘）。
+            (cur.drives && cur.drives.length > 1) ? React.createElement('div', { style: { display: 'flex', gap: 4, flexWrap: 'wrap', padding: '6px 12px', borderBottom: '1px solid ' + T.border } },
+              cur.drives.map((d) => {
+                const active = String(cur.path).toUpperCase().startsWith(String(d.name).toUpperCase())
+                return React.createElement('button', {
+                  key: d.path,
+                  onClick: () => loadLocal(d.path),
+                  disabled: loading,
+                  title: d.path,
+                  style: { ...buttonS, padding: '2px 8px', fontSize: 11, fontFamily: 'monospace', fontWeight: active ? 700 : 400, color: active ? T.ok : T.label },
+                }, d.name)
+              }),
+            ) : null,
             React.createElement('div', { style: { overflowY: 'auto', overflowX: 'hidden' } },
               loading ? React.createElement('div', { style: { opacity: 0.7, padding: 12 } }, '加载中…')
                 : (cur.entries.length ? cur.entries.slice(0, 400).map((it, i) => React.createElement('div', {
@@ -690,7 +703,7 @@ window.__ModuleLoader__.load({
                     React.createElement('span', null, '📁'),
                     React.createElement('span', { style: { overflow: 'hidden', textOverflow: 'ellipsis' } }, it.name),
                   )) : React.createElement('div', { style: { opacity: 0.6, padding: 12 } }, '（没有子目录 — 可直接选用当前目录）')),
-              cur.truncated ? React.createElement('div', { style: { opacity: 0.6, padding: '6px 12px', fontSize: 11 } }, '（条目过多已截断 — 其他盘/路径可直接在输入框填写）') : null,
+              cur.truncated ? React.createElement('div', { style: { opacity: 0.6, padding: '6px 12px', fontSize: 11 } }, '（条目过多已截断）') : null,
             ),
             err ? React.createElement('div', { style: { color: T.danger, fontSize: 12, padding: '4px 12px' } }, err) : null,
             React.createElement('div', { style: { display: 'flex', gap: 6, alignItems: 'center', padding: '8px 12px', borderTop: '1px solid ' + T.border } },
@@ -751,12 +764,12 @@ window.__ModuleLoader__.load({
         ),
         tab === 'local'
           ? React.createElement('div', { style: { display: 'flex', flexDirection: 'column', gap: 8 } },
-              React.createElement('div', { style: { fontSize: 12, opacity: 0.8 } }, '系统选择器优先；桌面版/远程宿主用内置目录浏览，也可直接输入本机目录。'),
+              React.createElement('div', { style: { fontSize: 12, opacity: 0.8 } }, '弹出系统文件夹对话框选择；不可用时用内置目录浏览，也可直接输入本机目录。'),
               React.createElement('div', { style: { display: 'flex', gap: 6 } },
                 React.createElement('input', { value: path, onChange: (e) => setPath(e.target.value), placeholder: '本机目录，如 C:\\Users\\you\\project', style: inputS }),
                 React.createElement('button', { style: buttonS, onClick: () => (path.trim() ? onPicked(path) : undefined), disabled: !path.trim() }, '选用此本地路径'),
               ),
-              React.createElement('button', { style: { ...buttonS, alignSelf: 'flex-start' }, onClick: chooseLocal, disabled: loading }, loading ? '打开中…' : '打开文件夹选择器'),
+              React.createElement('button', { style: { ...buttonS, alignSelf: 'flex-start' }, onClick: chooseLocal, disabled: loading }, loading ? '打开中…' : '打开系统文件夹选择器'),
               err ? React.createElement('div', { style: { color: T.danger, fontSize: 12 } }, err) : null,
               localPop ? renderLocalPopup() : null,
             )

--- a/lib/index.js
+++ b/lib/index.js
@@ -1818,6 +1818,18 @@ export async function apply(ctx, config) {
     throw new Error('当前系统不支持自动打开目录选择器，请在输入框直接填本地路径')
   }
 
+  /** The ctx.directoryPicker capability object, or null when the service is
+   * absent/unusable. Never throws — callers fall through to pickLocalNative. */
+  const localPickCapability = async () => {
+    const dp = (ctx && typeof ctx.get === 'function') ? (ctx.get('directoryPicker') || null) : null
+    if (!dp || typeof dp.capability !== 'function') return null
+    try {
+      return await Promise.resolve(dp.capability())
+    } catch {
+      return null
+    }
+  }
+
   // ── route helpers ─────────────────────────────────────────────────────────
   const routes = [
     {
@@ -2180,19 +2192,27 @@ export async function apply(ctx, config) {
         try {
           let outcome = null
           let via = 'service'
-          const dp = (ctx && typeof ctx.get === 'function') ? (ctx.get('directoryPicker') || null) : null
-          if (dp && typeof dp.capability === 'function') {
+          const cap = await localPickCapability()
+          if (cap && cap.kind === 'native' && typeof cap.pick === 'function') {
             try {
-              const cap = await Promise.resolve(dp.capability())
-              if (cap && cap.kind === 'native' && typeof cap.pick === 'function') {
-                const pickAbort = new AbortController()
-                const p = await Promise.resolve(cap.pick(pickAbort.signal || null))
-                pickAbort.abort()
-                outcome = (typeof p === 'string' && p) ? { path: p } : { cancelled: true }
-              }
+              const pickAbort = new AbortController()
+              const p = await Promise.resolve(cap.pick(pickAbort.signal || null))
+              pickAbort.abort()
+              outcome = (typeof p === 'string' && p) ? { path: p } : { cancelled: true }
             } catch (err) {
               outcome = null
             }
+          }
+          // DSH Desktop (Electron) deliberately mounts the BROWSE backend on
+          // win32 — the native backend's Win32 dialog worker spawns
+          // process.execPath as a plain node script, which cannot work inside
+          // an Electron binary. Honor the host's chosen interaction instead of
+          // ignoring it: hand the client an in-app local directory browser
+          // backed by /dsh-remote/local-list (+ /dsh-remote/local-mkdir).
+          // This also serves headless/remote hosts where no OS dialog can
+          // open but the browse capability still lists real directories.
+          if (!outcome && cap && cap.kind === 'browse' && typeof cap.list === 'function') {
+            return sendJson(res, 200, { ok: true, kind: 'browse', via: 'browse' })
           }
           if (!outcome) {
             via = 'own'
@@ -2204,6 +2224,51 @@ export async function apply(ctx, config) {
           }
           if (outcome.cancelled) return sendJson(res, 200, { ok: true, cancelled: true, via })
           return sendJson(res, 200, { ok: true, path: outcome.path, via })
+        } catch (err) {
+          return sendJson(res, 500, { ok: false, error: String((err && err.message) || err) })
+        }
+      },
+    },
+    {
+      kind: 'exact',
+      path: '/dsh-remote/local-list',
+      handler: async (req, res) => {
+        if (req.method !== 'GET') return sendJson(res, 405, { ok: false, error: 'method not allowed' })
+        try {
+          const cap = await localPickCapability()
+          if (!cap || cap.kind !== 'browse' || typeof cap.list !== 'function') return sendJson(res, 400, { ok: false, error: '当前目录选择器不是浏览后端，无法列出本机目录' })
+          const m = (req.url || '').match(/path=([^&]*)/)
+          const raw = m ? decodeURIComponent(m[1]) : ''
+          // No path → the browse backend lists the host home directory.
+          try {
+            const out = await Promise.resolve(cap.list(raw ? raw : undefined))
+            return sendJson(res, 200, { ok: true, ...out })
+          } catch (listErr) {
+            return sendJson(res, 400, { ok: false, error: String((listErr && listErr.message) || listErr), code: (listErr && listErr.code) || 'directory-unreadable' })
+          }
+        } catch (err) {
+          return sendJson(res, 500, { ok: false, error: String((err && err.message) || err) })
+        }
+      },
+    },
+    {
+      kind: 'exact',
+      path: '/dsh-remote/local-mkdir',
+      handler: async (req, res) => {
+        if (req.method !== 'POST') return sendJson(res, 405, { ok: false, error: 'method not allowed' })
+        try {
+          const cap = await localPickCapability()
+          if (!cap || cap.kind !== 'browse' || typeof cap.createDirectory !== 'function') return sendJson(res, 400, { ok: false, error: '当前目录选择器不是浏览后端，无法新建文件夹' })
+          const payload = JSON.parse((await readBody(req)) || '{}')
+          const p = String(payload.path || '')
+          const name = String(payload.name || '')
+          if (!p.trim() || !name.trim()) return sendJson(res, 400, { ok: false, error: 'path and name required' })
+          try {
+            const created = await Promise.resolve(cap.createDirectory(p, name))
+            return sendJson(res, 200, { ok: true, path: created })
+          } catch (mkErr) {
+            return sendJson(res, 400, { ok: false, error: String((mkErr && mkErr.message) || mkErr), code: (mkErr && mkErr.code) || 'directory-create-failed' })
+          }
         } catch (err) {
           return sendJson(res, 500, { ok: false, error: String((err && err.message) || err) })
         }

--- a/lib/index.js
+++ b/lib/index.js
@@ -1830,6 +1830,22 @@ export async function apply(ctx, config) {
     }
   }
 
+  /** Windows has no single filesystem root — enumerate fixed/mapped drive
+   * letters so the in-app browser can switch between them (the browse
+   * backend's crumbs stop at the current drive's root). Empty on POSIX. */
+  const listLocalDrives = () => {
+    if (process.platform !== 'win32') return []
+    const out = []
+    for (let i = 67; i <= 90; i++) { // C..Z (A/B are legacy floppy — skip)
+      const root = String.fromCharCode(i) + ':\\'
+      try {
+        statSync(root)
+        out.push({ name: root.slice(0, -1), path: root })
+      } catch {}
+    }
+    return out
+  }
+
   // ── route helpers ─────────────────────────────────────────────────────────
   const routes = [
     {
@@ -2203,22 +2219,24 @@ export async function apply(ctx, config) {
               outcome = null
             }
           }
-          // DSH Desktop (Electron) deliberately mounts the BROWSE backend on
-          // win32 — the native backend's Win32 dialog worker spawns
-          // process.execPath as a plain node script, which cannot work inside
-          // an Electron binary. Honor the host's chosen interaction instead of
-          // ignoring it: hand the client an in-app local directory browser
-          // backed by /dsh-remote/local-list (+ /dsh-remote/local-mkdir).
-          // This also serves headless/remote hosts where no OS dialog can
-          // open but the browse capability still lists real directories.
-          if (!outcome && cap && cap.kind === 'browse' && typeof cap.list === 'function') {
-            return sendJson(res, 200, { ok: true, kind: 'browse', via: 'browse' })
-          }
+          // Prefer a REAL OS dialog over the browse backend: operators expect
+          // an Explorer-style chooser, and the own spawn (PowerShell
+          // FolderBrowserDialog / osascript / zenity-kdialog) works even where
+          // the host mounted browse — DSH Desktop (Electron) deliberately
+          // mounts browse on win32 because the native backend's koffi dialog
+          // worker cannot run under Electron, but a plain child process can.
           if (!outcome) {
             via = 'own'
             try {
               outcome = await pickLocalNative()
             } catch (err) {
+              // No usable OS dialog (headless host, missing chooser binary):
+              // fall back to the host's browse capability — fs-only, works
+              // display-less — served as an in-app browser by the client
+              // (backed by /dsh-remote/local-list + /dsh-remote/local-mkdir).
+              if (cap && cap.kind === 'browse' && typeof cap.list === 'function') {
+                return sendJson(res, 200, { ok: true, kind: 'browse', via: 'browse' })
+              }
               return sendJson(res, 500, { ok: false, error: String((err && err.message) || err) + ' — 可直接在输入框填本地路径' })
             }
           }
@@ -2242,7 +2260,7 @@ export async function apply(ctx, config) {
           // No path → the browse backend lists the host home directory.
           try {
             const out = await Promise.resolve(cap.list(raw ? raw : undefined))
-            return sendJson(res, 200, { ok: true, ...out })
+            return sendJson(res, 200, { ok: true, ...out, drives: listLocalDrives() })
           } catch (listErr) {
             return sendJson(res, 400, { ok: false, error: String((listErr && listErr.message) || listErr), code: (listErr && listErr.code) || 'directory-unreadable' })
           }


### PR DESCRIPTION
## 问题

**DSH 桌面版（Electron，Windows/macOS）中，「选择工作目录」弹窗的本机目录选择完全不可用**（≤ 0.8.6），点「打开系统文件夹选择器」报错：

> 本地目录选择器不可用（当前为非原生/浏览后端，请在输入框手动填本地路径）

## 根因

DSH 桌面版启动器在 Windows 上**故意**禁用 `@deepseek-ai/dsh-host-directory-picker-auto`，强制挂载 **browse 后端**（`desktop-directory-picker-browse-host/surface`，见桌面版 `app.asar.unpacked/lib/profile.js` 的 `prepareDesktopProfile()`）。原因：native 后端在 Windows 上靠 `spawn(process.execPath, [worker.cjs])` 起子进程开 Win32 COM 文件对话框，而桌面版里 `process.execPath` 是 Electron 可执行文件，必然失败。

而 `local-pick` 只消费 `kind === 'native'`：

- 桌面版上 capability 永远是 browse → 永远落到自持兜底（PowerShell FolderBrowserDialog）。虽然能弹框，但宿主选择的交互被完全忽略；
- 更关键的是**无显示/远程宿主**场景（SSH 启动、Linux 无 zenity/kdialog）：browse 后端是纯文件系统实现、不需要显示器，明明完全可用，插件却完全无视它，直接报“未找到目录选择器程序”。

## 修复

按宿主挂载的 capability 分支：**native（OS 对话框）→ browse（内置浏览器）→ 自持 spawn 兜底**：

- `local-pick`：capability 经空安全 helper 解析一次；browse 时返回 `{ ok: true, kind: 'browse' }` 让客户端打开内置浏览器；
- 新增 `GET /dsh-remote/local-list?path=`：代理 browse `list(path)`（不传 path = 宿主家目录），返回 `{ path, home, crumbs, entries, truncated }`；
- 新增 `POST /dsh-remote/local-mkdir`：代理 browse `createDirectory(path, name)`；
- 客户端：本机目录浏览浮层（进入子目录 / 面包屑跳转含盘符根 / 🏠 家目录 / 新建文件夹 / 「选用此路径」回填输入框复核后提交），与远程浏览弹层同一套交互风格。

已在真实环境（DSH Desktop 0.x + Windows）验证：桌面版弹窗 → 内置浏览器 → 逐级进入 → 选用 → 工作区正常创建。

## 测试

- `node --check` lib/index.js、lib/client.js 通过
- `node check.mjs` 通过（command/tool/route/schema lint 全绿）
- `npm test`：45 pass / 0 fail