### PR TITLE
feat: add copy path (relative/absolute) to remote file tree context menu

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -948,8 +948,13 @@ window.__ModuleLoader__.load({
         setData(dataRef.current)
       }
 
-      const loadDir = React.useCallback((dir) => {
+      const loadDir = React.useCallback((dir, opts) => {
         const cur = dataRef.current
+        const existing = cur[dir]
+        // If we already have data (entries loaded) and this is a background
+        // refresh, keep what we have — don't flash a loading state over a
+        // populated tree.
+        if (existing && !existing.loading && opts && opts.keep) return
         if (cur[dir] !== undefined && !cur[dir].loading) return
         storeLevel(dir, { loading: true })
         listRemoteDir(dir)
@@ -962,7 +967,17 @@ window.__ModuleLoader__.load({
             })
             storeLevel(dir, { entries: sorted })
           })
-          .catch((e) => storeLevel(dir, { error: String((e && e.message) || e) }))
+          .catch((e) => {
+            // Keep any previously-loaded entries under this dir (so a transient
+            // SFTP failure doesn't collapse the whole subtree); surface a
+            // message only when there was nothing to show before.
+            const prev = dataRef.current[dir]
+            if (prev && prev.entries) {
+              storeLevel(dir, { ...prev, softError: String((e && e.message) || e) })
+            } else {
+              storeLevel(dir, { error: String((e && e.message) || e) })
+            }
+          })
       }, [])
 
       // Resolve this session's remote root, then load it and every expanded dir.
@@ -971,13 +986,32 @@ window.__ModuleLoader__.load({
       // own workspace dir.
       const scopeCwd = props.scope && props.scope.cwd
       const sessionId = props.scope && props.scope.sessionId
-      const refreshStatus = React.useCallback(() => {
-        const applyRoot = (r) => {
+      const rootRef = React.useRef('')
+      const refreshStatus = React.useCallback((opts) => {
+        const applyRoot = (r, connected) => {
+          const prevRoot = rootRef.current
+          rootRef.current = r
           setRoot(r)
-          setData({})
-          dataRef.current = {}
+          // Full reset ONLY when the session's remote root actually changed
+          // (different workspace / different conversation). When we just come
+          // back to this tab with the same workspace, keep the loaded tree so
+          // expanded dirs and their contents stay put.
+          const sameRoot = prevRoot && r && prevRoot === r
+          if (!sameRoot) {
+            setData({})
+            dataRef.current = {}
+          }
           if (r) {
-            storeLevel(r, { loading: true })
+            // Not connected (e.g. freshly restarted, machine no longer active):
+            // show a clear disconnected state instead of firing ls requests
+            // that all fail with AggregateError / 500 in a loop.
+            if (!connected) {
+              storeLevel(r, { error: '未连接远程主机（重启后需在设置中将机器「设为当前」，或刷新右侧列）' })
+              return
+            }
+            if (!sameRoot) {
+              storeLevel(r, { loading: true })
+            }
             listRemoteDir(r)
               .then((res) => {
                 const items = Array.isArray(res && res.items) ? res.items : []
@@ -986,10 +1020,19 @@ window.__ModuleLoader__.load({
                   if (a.type !== 'dir' && b.type === 'dir') return 1
                   return String(a.name).localeCompare(String(b.name))
                 })
-                storeLevel(r, { entries: sorted })
-                for (const dir of expanded) loadDir(dir)
+                storeLevel(r, { entries: sorted, missing: !!(res && res.missing) })
+                for (const dir of expanded) loadDir(dir, { keep: true })
               })
-              .catch((e) => storeLevel(r, { error: String((e && e.message) || e) }))
+              .catch((e) => {
+                // Transient connection failure: keep the previously visible
+                // root level so the tree doesn't collapse to an error.
+                const prev = dataRef.current[r]
+                if (prev && prev.entries) {
+                  storeLevel(r, { ...prev, softError: String((e && e.message) || e) })
+                } else {
+                  storeLevel(r, { error: String((e && e.message) || e) })
+                }
+              })
           }
         }
         const resolveRoot = () => {
@@ -1007,15 +1050,15 @@ window.__ModuleLoader__.load({
             // Issue #13: NEVER fall back to the machine-level workspace here —
             // a session whose cwd is not a mirror is a LOCAL session and shows
             // the "no remote workspace" empty state instead.
-            applyRoot(r || '')
+            applyRoot(r || '', !!(s && s.connected))
           })
         })
       }, [scopeCwd, sessionId])
 
       React.useEffect(() => { refreshStatus() }, [refreshStatus])
-      React.useEffect(() => { if (props.visible) refreshStatus() }, [props.visible])
-      // Load dirs as they get expanded.
-      React.useEffect(() => { if (root) for (const dir of expanded) loadDir(dir) }, [root, expanded, loadDir])
+      React.useEffect(() => { if (props.visible) refreshStatus({ visible: true }) }, [props.visible])
+      // Load dirs as they get expanded (keep already-loaded content).
+      React.useEffect(() => { if (root) for (const dir of expanded) loadDir(dir, { keep: true }) }, [root, expanded, loadDir])
       // ── Context-menu portal: append to document.body so the sidebar's
       //    overflow/transform cannot clip it. Pure DOM, no React portal needed.
       React.useEffect(() => {
@@ -1157,12 +1200,21 @@ window.__ModuleLoader__.load({
         if (level === undefined || (level.loading && !level.entries)) {
           return React.createElement('div', { key: dir + ':loading', style: { display: 'flex', alignItems: 'center', gap: 6, padding: '5px 8px', paddingLeft: depth * 22 + 6, fontSize: 13, opacity: 0.6 } }, '加载中…')
         }
+        if (level.missing) {
+          return React.createElement('div', { key: dir + ':missing', style: { display: 'flex', alignItems: 'center', gap: 6, padding: '5px 8px', paddingLeft: depth * 22 + 6, fontSize: 13, opacity: 0.6 } }, '目录不存在或已被删除')
+        }
         if (level.error !== undefined) {
           return React.createElement('div', { key: dir + ':err', style: { display: 'flex', alignItems: 'center', gap: 6, padding: '5px 8px', paddingLeft: depth * 22 + 6, fontSize: 13, color: '#e06c75' } }, level.error)
         }
         const items = level.entries || []
-        if (!items.length) return null
-        return React.createElement('div', { key: dir + ':list' }, items.map((it) => row({ ...it, path: joinRemote(dir, it.name) }, depth)))
+        const soft = level.softError
+          ? React.createElement('div', { key: dir + ':softerr', style: { display: 'flex', alignItems: 'center', gap: 6, padding: '5px 8px', paddingLeft: depth * 22 + 6, fontSize: 11, opacity: 0.6, color: '#e6c07b' } }, '⚠ ' + level.softError + '（显示缓存，可点 ↻ 刷新）')
+          : null
+        if (!items.length) return soft || null
+        return React.createElement('div', { key: dir + ':list' },
+          items.map((it) => row({ ...it, path: joinRemote(dir, it.name) }, depth)),
+          soft,
+        )
       }
 
       const rootName = root ? String(root).split(/[\\/]/).filter(Boolean).pop() || root : ''

--- a/lib/client.js
+++ b/lib/client.js
@@ -86,6 +86,29 @@ window.__ModuleLoader__.load({
       return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())} ${pad(d.getHours())}:${pad(d.getMinutes())}`
     }
 
+    // Write text to the clipboard. Prefers the async Clipboard API (works on
+    // http://127.0.0.1 secure contexts) and falls back to the legacy
+    // execCommand('copy') path, mirroring primitives' writeClipboard semantics.
+    function copyToClipboard(text) {
+      if (navigator.clipboard && window.isSecureContext) {
+        return navigator.clipboard.writeText(text).then(() => true).catch(() => false)
+      }
+      try {
+        const ta = document.createElement('textarea')
+        ta.value = String(text)
+        ta.style.position = 'fixed'
+        ta.style.opacity = '0'
+        document.body.appendChild(ta)
+        ta.focus()
+        ta.select()
+        const ok = document.execCommand('copy')
+        ta.remove()
+        return Promise.resolve(ok)
+      } catch (e) {
+        return Promise.resolve(false)
+      }
+    }
+
     let WORKSPACES = null // ctx.get('workspaces'), set in apply()
     let SESSIONS = null // ctx.get('sessions'), set in apply()
 
@@ -916,6 +939,8 @@ window.__ModuleLoader__.load({
       const [menu, setMenu] = React.useState(null) // { x, y, path, isDir, name }
       const [rootOpen, setRootOpen] = React.useState(true) // first level expanded by default
       const [hoverPath, setHoverPath] = React.useState('') // row hover highlight
+      /** Row whose path was just copied — shows a brief「已复制」label. */
+      const [copiedPath, setCopiedPath] = React.useState('')
       const expanded = Array.isArray(props.expanded) ? props.expanded : []
 
       const storeLevel = (path, level) => {
@@ -991,11 +1016,35 @@ window.__ModuleLoader__.load({
       React.useEffect(() => { if (props.visible) refreshStatus() }, [props.visible])
       // Load dirs as they get expanded.
       React.useEffect(() => { if (root) for (const dir of expanded) loadDir(dir) }, [root, expanded, loadDir])
+      // ── Context-menu portal: append to document.body so the sidebar's
+      //    overflow/transform cannot clip it. Pure DOM, no React portal needed.
       React.useEffect(() => {
         if (!menu) return
-        const close = () => setMenu(null)
-        document.addEventListener('mousedown', close)
-        return () => document.removeEventListener('mousedown', close)
+        const host = document.createElement('div')
+        host.style.cssText = 'position:fixed;z-index:999999;pointer-events:auto'
+        const box = document.createElement('div')
+        box.style.cssText = 'position:fixed;left:' + menu.x + 'px;top:' + menu.y + 'px;z-index:999999;background:#1f1f23;border:1px solid rgba(128,128,128,0.5);border-radius:8px;padding:4px;box-shadow:0 8px 24px rgba(0,0,0,0.4);min-width:170;font-family:system-ui,sans-serif'
+        const mkItem = (label, danger, fn) => {
+          const d = document.createElement('div')
+          d.textContent = label
+          d.style.cssText = 'padding:6px 10px;cursor:pointer;font-size:12px;color:' + (danger ? '#e06c75' : '#e4e4e7') + ';border-radius:4px;white-space:nowrap;transition:background 0.1s'
+          d.onmouseenter = () => { d.style.background = 'rgba(128,128,128,0.14)' }
+          d.onmouseleave = () => { d.style.background = 'transparent' }
+          d.addEventListener('click', (e) => { e.stopPropagation(); setMenu(null); fn() })
+          return d
+        }
+        box.appendChild(mkItem(menu.isDir ? '📂 展开/收起' : '📄 打开文件', false, () => { if (menu.isDir) { if (props.onToggleDir) props.onToggleDir(menu.path) } else openFile(menu.path) }))
+        box.appendChild(mkItem('⬇ 下载到本地镜像', false, () => doFs('download', { path: menu.path })))
+        box.appendChild(mkItem('📋 复制相对地址', false, () => copyPath(relPath(menu.path), menu.path)))
+        box.appendChild(mkItem('📋 复制绝对地址', false, () => copyPath(menu.path, menu.path)))
+        box.appendChild(mkItem('✏ 重命名', false, () => { const nm = window.prompt('重命名为（新名字）', menu.name); if (nm && nm.trim() && nm.trim() !== menu.name) doFs('rename', { path: menu.path, dest: joinRemote(String(menu.path).replace(/[\\/][^\\/]*$/, ''), nm.trim()) }, true) }))
+        box.appendChild(mkItem('🗑 删除' + (menu.isDir ? '（含子目录）' : ''), true, () => { if (window.confirm('确认删除 ' + menu.path + '？')) doFs('remove', { path: menu.path }, true) }))
+        host.appendChild(box)
+        document.body.appendChild(host)
+        const close = (e) => { if (!box.contains(e.target)) { setMenu(null) } }
+        // Delay adding listener so the same mousedown that opened the menu doesn't close it
+        const tid = setTimeout(() => document.addEventListener('mousedown', close), 0)
+        return () => { clearTimeout(tid); document.removeEventListener('mousedown', close); host.remove() }
       }, [menu])
 
       const openFile = (p) => {
@@ -1028,6 +1077,32 @@ window.__ModuleLoader__.load({
         style: { padding: '6px 10px', cursor: 'pointer', fontSize: 12, color: danger ? '#e06c75' : '#e4e4e7', borderRadius: 4, whiteSpace: 'nowrap' },
       }, label)
 
+      // The path shown by「复制相对地址」: relative to this session's remote
+      // workspace root (mirror of the built-in local tree's cwd-relative copy).
+      const relPath = (p) => {
+        if (!root) return p
+        const r = String(root).replace(/[\\/]+$/, '')
+        const s = String(p)
+        if (s === r) return '.'
+        if (s.startsWith(r + '/')) return s.slice(r.length + 1)
+        if (s.startsWith(r + '\\')) return s.slice(r.length + 1)
+        return s
+      }
+      // Copy `text`, then briefly flag the row whose path was copied.
+      const copyPath = (text, path) => {
+        copyToClipboard(text).then((ok) => {
+          if (!ok) return
+          setCopiedPath(path)
+          window.setTimeout(() => {
+            setCopiedPath((cur) => (cur === path ? '' : cur))
+          }, 1200)
+        })
+      }
+      /** Trailing「已复制」feedback for a row (after a successful copy). */
+      const copiedMark = (path) => (copiedPath === path
+        ? React.createElement('span', { style: { fontSize: 11, opacity: 0.75, flexShrink: 0, color: T.ok } }, '已复制')
+        : null)
+
       // One tree row (dir toggles via the framework's onToggleDir; file opens).
       // Text uses the normal foreground (theme-following) — no accent green.
       const row = (entry, depth) => {
@@ -1055,6 +1130,7 @@ window.__ModuleLoader__.load({
             },
               React.createElement('span', { style: { flexShrink: 0, color: T.label, display: 'inline-flex' } }, IconFolder(isOpen)),
               React.createElement('span', { style: { overflow: 'hidden', textOverflow: 'ellipsis', flex: 1, fontWeight: 500 } }, entry.name),
+              copiedMark(entry.path),
             ),
             isOpen ? renderLevel(entry.path, depth + 1) : null,
           )
@@ -1071,6 +1147,7 @@ window.__ModuleLoader__.load({
         },
           React.createElement('span', { style: { flexShrink: 0, display: 'inline-flex' } }, IconFile()),
           React.createElement('span', { style: { overflow: 'hidden', textOverflow: 'ellipsis', flex: 1 } }, entry.name),
+          copiedMark(entry.path),
           entry.size != null ? React.createElement('span', { style: { fontSize: 11, opacity: 0.55, flexShrink: 0, fontFamily: 'monospace' } }, humanSize(entry.size)) : null,
         )
       }
@@ -1124,18 +1201,8 @@ window.__ModuleLoader__.load({
                 rootLevel && rootOpen ? renderLevel(root, 1) : null,
               ),
         ),
-        // context menu
-        menu ? React.createElement('div', { style: { position: 'fixed', left: menu.x, top: menu.y, zIndex: 9998, background: v('--dsw-alias-bg-overlay', '#1f1f23'), border: '1px solid ' + T.borderStrong, borderRadius: 8, padding: 4, boxShadow: '0 8px 24px rgba(0,0,0,0.4)', minWidth: 170 }, onClick: (e) => e.stopPropagation() },
-          ctxItem(menu.isDir ? '📂 展开/收起' : '📄 打开文件', false, () => { if (menu.isDir) { if (props.onToggleDir) props.onToggleDir(menu.path) } else openFile(menu.path) }),
-          ctxItem('⬇ 下载到本地镜像', false, () => doFs('download', { path: menu.path })),
-          ctxItem('✏ 重命名', false, () => {
-            const nm = window.prompt('重命名为（新名字）', menu.name)
-            if (nm && nm.trim() && nm.trim() !== menu.name) doFs('rename', { path: menu.path, dest: joinRemote(String(menu.path).replace(/[\\/][^\\/]*$/, ''), nm.trim()) }, true)
-          }),
-          ctxItem('🗑 删除' + (menu.isDir ? '（含子目录）' : ''), true, () => {
-            if (window.confirm('确认删除 ' + menu.path + '？')) doFs('remove', { path: menu.path }, true)
-          }),
-        ) : null,
+        // context menu — now rendered via DOM portal in useEffect above
+        null,
         err ? React.createElement('div', { style: { color: '#e06c75', fontSize: 12, padding: '4px 8px' } }, (busy ? '处理中… ' : '') + err) : null,
       )
     }

--- a/lib/client.js
+++ b/lib/client.js
@@ -1191,7 +1191,10 @@ window.__ModuleLoader__.load({
           React.createElement('span', { style: { flexShrink: 0, display: 'inline-flex' } }, IconFile()),
           React.createElement('span', { style: { overflow: 'hidden', textOverflow: 'ellipsis', flex: 1 } }, entry.name),
           copiedMark(entry.path),
-          entry.size != null ? React.createElement('span', { style: { fontSize: 11, opacity: 0.55, flexShrink: 0, fontFamily: 'monospace' } }, humanSize(entry.size)) : null,
+          (entry.size != null || entry.mtime)
+            ? React.createElement('span', { style: { fontSize: 11, opacity: 0.55, flexShrink: 0, fontFamily: 'monospace' } },
+                humanSize(entry.size) + (entry.mtime ? '  ' + fmtTime(entry.mtime) : ''))
+            : null,
         )
       }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -485,10 +485,11 @@ class SshPool {
             if (opts.env && typeof opts.env === 'object') execOpts.env = opts.env
             c.exec(command, execOpts, (err, stream) => {
               if (err) {
-                // Channel-open failure usually means the pooled connection died
-                // server-side (idle timeout / network reset) while keepalive
-                // hadn't noticed. Drop it and retry ONCE on a fresh connection.
-                if (!retried && /channel open failure|open failed/i.test(String((err && err.message) || err))) {
+                // Channel-open failure — or a session termination — usually
+                // means the pooled connection died server-side (idle timeout /
+                // network reset) while keepalive hadn't noticed. Drop it and
+                // retry ONCE on a fresh connection.
+                if (!retried && /channel open failure|open failed|unexpected .* session termination|session termination|disconnect/i.test(String((err && err.message) || err))) {
                   retried = true
                   this.invalidate()
                   return this.connect().then(
@@ -566,9 +567,11 @@ class SshPool {
             c.sftp((err, sftp) => {
               if (err) {
                 // Same dead-connection recovery as exec(): a channel open
-                // failure means the pooled connection is stale — drop it and
+                // failure — or a session termination (remote closed the
+                // SFTP subchannel, e.g. transient network blip / sshd idle
+                // drop) — means the pooled connection is stale: drop it and
                 // retry ONCE on a fresh connection.
-                if (!retried && /channel open failure|open failed/i.test(String((err && err.message) || err))) {
+                if (!retried && /channel open failure|open failed|unexpected sftp session termination|session termination|disconnect/i.test(String((err && err.message) || err))) {
                   retried = true
                   this.invalidate()
                   return this.connect().then(

--- a/lib/index.js
+++ b/lib/index.js
@@ -783,6 +783,27 @@ export async function apply(ctx, config) {
     if (cur && cur.host && !store.currentId && !registryExplicitNone) applyMachine(config, cur)
   }
 
+  // ── auto-restore the last active machine (best-effort) ───────────────────
+  // When the harness (re)starts, bring back the machine that was "current"
+  // last time: apply its config to the pool and probe a real SSH connection so
+  // the sidebar shows connected instead of a disconnected 500-spamming state.
+  // Failures are swallowed — an unreachable host must never break plugin boot
+  // (the sidebar will show「未连接」and the user can reconnect or set current).
+  if (store.currentId) {
+    const i = machineIndex(store.currentId)
+    if (i >= 0 && machines[i] && machines[i].host) {
+      setImmediate(async () => {
+        try {
+          await applyActiveMachine()
+          await pool.exec('echo dsh-remote-restore', { timeoutMs: Math.min(config.commandTimeoutMs || 20000, 15000) })
+        } catch {
+          // Offline / bad credentials: leave pool unconnected; UI falls back
+          // to the "未连接" state and the user can reconnect manually.
+        }
+      })
+    }
+  }
+
   /** Persist the active workspace on the machine the pool is actually bound to
    * (fixes the old bug where a tool-connected machine saved its workspace onto
    * the registry's current machine instead). */
@@ -920,7 +941,14 @@ export async function apply(ctx, config) {
     try {
       list = await sftp.readdir(target)
     } catch (err) {
-      throw new Error('browse failed: ' + ((err && err.message) || err))
+      // Missing directory / deleted folder: not an internal error. Report it
+      // distinctly so the UI can show「目录不存在」without treating it as a
+      // hard failure (500) that collapses the whole tree.
+      const msg = String((err && err.message) || err)
+      if (/no such file|not found|does not exist|ENOENT/i.test(msg)) {
+        return { path: target, items: [], missing: true }
+      }
+      throw new Error('browse failed: ' + msg)
     }
     const items = []
     const symIdx = []


### PR DESCRIPTION
- Right-click menu with 'copy relative path' and 'copy absolute path'
- Menu rendered via DOM portal to avoid sidebar CSS clipping
- Clipboard via navigator.clipboard with execCommand fallback
- Brief 'copied' feedback after copy