### PR TITLE
fix(0.8.10): Fix rw_upload parameter sequencing (remote, local)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,25 @@
 
 All notable changes to **dsh-remote**.
 
+## 0.8.10 — 2026-08-31
+### 修复：`rw_upload` 自引入即坏 —— `sftp.fastPut` 参数顺序颠倒（ssh2 契约为 `fastPut(本地, 远程)`）
+
+- **根因**：`rw_upload` 调用的是 `sftp.fastPut(rp, lp)`，把**远程路径当本地路径**传给了
+  ssh2。ssh2 的真实签名是 `fastPut(localPath, remotePath)`（与
+  `fastGet(remotePath, localPath)` 恰好相反），于是 ssh2 尝试把远程路径当本地文件打开：
+  Windows 上 `/home/…` 按当前盘解析为
+  `C:\home\…` → `ENOENT: no such file or directory, open 'C:\home\…'`。即使传入
+  完全正确的 `localPath`（如 `D:/…`）也必然失败 —— 该工具自
+  0.6.x 引入以来从未成功过。`rw_push` / `rw_sync` / `rw_download` 走 `writeFile` /
+  `fastGet`，参数顺序本来就正确，不受影响。
+- **修复**：改为 `sftp.fastPut(lp, rp)`（本地在前）；SFTP wrapper 的参数名同步改为
+  `(lp, p)` 并注明 ssh2 契约，防止回归。
+- **回归测试**：新增 `test/upload.test.js` —— 原型替换 `ssh2.Client`（完全离线），
+  驱动真实 `apply()` + 连接池 + SFTP wrapper，断言 `fastPut` 收到 `(本地, 远程)` 顺序；
+  该测试对旧顺序如约失败。
+- **连带纠正**：`test/helpers.js` 的 `MemFs.fastPut` mock 此前也编码了颠倒的顺序
+  （潜在坑：任何基于它的测试都无法发现这类 bug），已纠正为真实契约。
+
 ## 0.8.9 — 2026-08-29
 ### 新增：Git Bash 默认终端（Windows 主机）+ 「此电脑」多盘根视图 + Windows 路径自动改写；修复浏览浮层「回上一级」与路径栏残留上次选择
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -732,7 +732,7 @@ class SshPool {
                 readFile: (p) => withTimeout((d, cb) => sftp.readFile(d, cb))(P(p)),
                 writeFile: (p, data) => withTimeout((d, data2, cb) => sftp.writeFile(d, data2, cb))(P(p), data),
                 fastGet: (p, lp) => withTimeout((d, l, cb) => sftp.fastGet(d, l, cb))(P(p), lp),
-                fastPut: (p, lp) => withTimeout((d, l, cb) => sftp.fastPut(d, l, cb))(P(p), lp),
+                fastPut: (lp, p) => withTimeout((l, d, cb) => sftp.fastPut(l, d, cb))(lp, P(p)),
               })
             })
           }
@@ -1896,7 +1896,7 @@ export async function apply(ctx, config) {
         const sftp = await pool.sftp()
         await mkdirRemoteDirs(sftp, remoteDirname(rp))
         const st = statSync(lp)
-        await sftp.fastPut(rp, lp)
+        await sftp.fastPut(lp, rp)
         audit('upload', `upload ${lp} → ${rp}`, 0)
         return { ok: true, bytes: st.size, text: `uploaded ${st.size} bytes from ${lp} → ${rp}` }
       },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dsh-remote",
-  "version": "0.8.9",
+  "version": "0.8.10",
   "description": "Remote-work assistant for DeepSeek Harness: connect SSH (password/key/agent/keyboard-interactive/proxy jump), pick a remote workspace, operate on it with 21 rw_* tools (incl. rw_edit/rw_stat/rw_mkdir/rw_remove/rw_move/rw_forward), conflict-aware mirror sync, port forwarding, side-bar remote file editing, audit log, keychain passwords.",
   "license": "MIT",
   "author": "flymysql <flyphp@outlook.com>",

--- a/test/helpers.js
+++ b/test/helpers.js
@@ -59,7 +59,7 @@ export function makeSftp(fs) {
     readFile: (p) => Promise.resolve(fs.readFileSync(p)),
     writeFile: (p, buf) => { fs.writeFileSync(p, buf); return Promise.resolve() },
     fastGet: (p, lp) => { fs.writeFileSync('@local:' + lp, fs.readFileSync(p)); return Promise.resolve() },
-    fastPut: (p, lp) => { fs.writeFileSync(p, fs.readFileSync('@local:' + lp)); return Promise.resolve() },
+    fastPut: (lp, p) => { fs.writeFileSync(p, fs.readFileSync('@local:' + lp)); return Promise.resolve() },
   }
 }
 

--- a/test/upload.test.js
+++ b/test/upload.test.js
@@ -1,0 +1,94 @@
+// Regression test for rw_upload (0.8.10).
+//
+// Root cause of the reported bug ("ENOENT ... open 'C:\home\…'"): the
+// tool called sftp.fastPut(remotePath, localPath) — swapped vs ssh2's real
+// contract fastPut(LOCAL path, REMOTE path) — so ssh2 opened the REMOTE path
+// as a Windows local file (resolving /home/… against the C: drive), even when
+// localPath was perfectly valid.
+//
+// Hermetic: ssh2.Client is prototype-patched (connect/sftp/end), so the real
+// plugin apply() + pool + SFTP wrapper run end-to-end without any network.
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import path from 'node:path'
+import { mkdtempSync, writeFileSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import ssh2 from 'ssh2'
+import { apply } from '../lib/index.js'
+
+const recorded = { fastPut: [], mkdir: [] }
+
+// Fake Client surface. Argument ORDER matters: this fake encodes ssh2's real
+// contract — fastPut(localPath, remotePath).
+ssh2.Client.prototype.connect = function () {
+  const self = this
+  setImmediate(() => self.emit('ready'))
+}
+ssh2.Client.prototype.end = function () {}
+ssh2.Client.prototype.sftp = function (cb) {
+  const sftp = {
+    mkdir: (p, cb2) => { recorded.mkdir.push(p); cb2(null) },
+    fastPut: (lp, p, cb2) => { recorded.fastPut.push([lp, p]); cb2(null) },
+  }
+  setImmediate(() => cb(null, sftp))
+}
+
+/** Boot the real plugin against a throwaway DSH_HOME and return rw_upload. */
+async function setup(t) {
+  const home = mkdtempSync(path.join(tmpdir(), 'dsh-upload-test-'))
+  t.after(() => rmSync(home, { recursive: true, force: true }))
+  process.env.DSH_HOME = home
+  const tools = {}
+  await apply(
+    {
+      effect: () => {},
+      get: () => undefined,
+      systemPrompt: { section: () => {} },
+      tools: { register: (tool) => { tools[tool.name] = tool } },
+    },
+    {
+      host: '203.0.113.10', port: 22, username: 'tester', password: 'x',
+      commandTimeoutMs: 5000, connectTimeoutMs: 5000,
+    },
+  )
+  const upload = tools['rw_upload']
+  assert.ok(upload, 'rw_upload is registered')
+  recorded.fastPut.length = 0
+  recorded.mkdir.length = 0
+  return { upload }
+}
+
+test('rw_upload passes (localPath, remotePath) to fastPut — the C:\\home\\… ENOENT regression', async (t) => {
+  const { upload } = await setup(t)
+  const localFile = path.join(tmpdir(), `dsh-upload-src-${process.pid}.md`)
+  writeFileSync(localFile, '# real local file')
+  t.after(() => rmSync(localFile, { force: true }))
+  recorded.fastPut.length = 0
+  recorded.mkdir.length = 0
+
+  const ws = '/home/user/data'
+  const res = await upload.execute(
+    { localPath: localFile, path: `${ws}/document.md` },
+    {},
+  )
+  assert.equal(res.ok, true, 'upload succeeds')
+  assert.equal(recorded.fastPut.length, 1, 'exactly one fastPut')
+  const [argLocal, argRemote] = recorded.fastPut[0]
+  assert.equal(argLocal, localFile, 'fastPut arg1 is the LOCAL file (was swapped → ENOENT)')
+  assert.equal(argRemote, `${ws}/document.md`, 'fastPut arg2 is the REMOTE path')
+  assert.ok(recorded.mkdir.includes(ws), 'remote parent dir created (not the file path)')
+})
+
+test('rw_upload still rejects a missing local file with the original error', async (t) => {
+  const { upload } = await setup(t)
+  const missing = path.join(tmpdir(), `dsh-upload-missing-${process.pid}.txt`)
+  await assert.rejects(
+    () => upload.execute({ localPath: missing, path: '/out/x.txt' }, {}),
+    (err) => {
+      assert.match(err.message, /local file not found/)
+      assert.ok(err.message.includes(missing), 'error names the local path')
+      return true
+    },
+  )
+  assert.equal(recorded.fastPut.length, 0, 'no SFTP write attempted')
+})


### PR DESCRIPTION
This patch should fix the previous errors in rw_upload due to incorrect parameter sequence in calling ssh2 fastPut() method. 

The issue is previously hidden by that nowadays agents could come up with bypassing commands, yet they induce extra token cost and distractions. After the fix the rw_upload behaves as intended without requiring following calls.